### PR TITLE
Adds ncp as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "electron-packager": "^13.0.1",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",
+    "ncp": "^2.0.0",
     "node-sass": "^4.11.0",
     "prettier": "^1.15.3",
     "sass-loader": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,6 +2783,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
 needle@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"


### PR DESCRIPTION
As of now running yarn run production or package results in an error. This should fix this but it would be good to know if this is even an issue for everyone before merging.