### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: node_js
 
 node_js: '10'
 
+env:
+  - YARN_GPG=no
+
 cache:
   yarn: true
-
-addons:
-  chrome: stable
 
 script:
   - yarn test


### PR DESCRIPTION
Mac builds have been broken due to homebrew. Worst case I add Appvoyer for Windows for the time being.