### PR TITLE
Apply drag-to-tag to all selected files

### DIFF
--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -35,35 +35,52 @@
 }
 
 /////////////////////// Thumbnail //////////////////////////////////
+#gallery-content.selected-file-dropping {
+  [role='gridcell'],
+  [data-masonrycell] {
+    &[aria-selected='true'] .thumbnail {
+      // If selected, and any other selected image is a drop target: normal yellow border
+      // (as an indication that dropping a tag will apply it to all selected files)
+      background-color: $yellow1;
+    }
+  }
+}
+
+// Wrapper around .thumbnail:
 [role='gridcell'],
 [data-masonrycell] {
   position: relative;
   margin: 4px;
 
   &[aria-selected='true'] .thumbnail {
+    // If selected, show a blue border
     background-color: var(--accent-color-blue);
-
-    // old design
-    // > img,
-    // > .image-error {
-    //   clip-path: inset(0.25rem round 0.125rem); // old design
-    // }
-
-    // New design
-    > img {
-      border: 0.25rem solid var(--accent-color-blue); // new design
+    > img,
+    > .image-error {
+      clip-path: inset(0.25rem round 0.125rem); // old design
     }
+    
+    // If selected AND drop target: big yellow border
+    &[data-dnd-target='true'] {
+      background-color: $yellow1;
+      > img,
+      > .image-error {
+        clip-path: inset(0.5rem round 0.125rem);
+      }
+    }
+
     > .image-error {
       border: 0.25rem solid $danger; // new design
     }
   }
 
-  &.open img {
-    outline-color: red;
-    outline-width: 5px;
-    outline-offset: -5px;
-    outline-style: solid;
-  }
+  // TODO: can this be removed?
+  // &.open img {
+  //   outline-color: red;
+  //   outline-width: 5px;
+  //   outline-offset: -5px;
+  //   outline-style: solid;
+  // }
 
   &:hover .thumbnail-tags {
     max-height: var(--thumbnail-size);
@@ -80,6 +97,8 @@
   background-color: var(--background-color-alt);
   border: 0.0625rem solid var(--border-dark);
   border-radius: 0.25rem;
+
+  transition: background-color 0.2s $pt-transition-cubic2;
 
   // This acts as the border-radius, but also for child elements
   :first-child {
@@ -99,7 +118,7 @@
   }
 
   &[data-dnd-target='true'] {
-    background: $yellow1;
+    background-color: $yellow1;
 
     img {
       clip-path: inset(0.5rem round 0.125rem);

--- a/resources/style/remake/layout.scss
+++ b/resources/style/remake/layout.scss
@@ -61,6 +61,8 @@ body {
   height: calc(100% - var(--window-titlebar-height));
   z-index: 1;
 
+  margin-left: -2px; // align it with the actual outliner edge
+
   width: 4px;
   opacity: 0;
   cursor: col-resize;

--- a/src/frontend/components/RemovalAlert.tsx
+++ b/src/frontend/components/RemovalAlert.tsx
@@ -75,7 +75,9 @@ export const FileRemoval = observer(() => {
   return (
     <RemovalAlert
       open={uiStore.isToolbarFileRemoverOpen}
-      title={`Are you sure you want to delete ${selection.size} missing file${selection.size > 1 ? 's' : ''}?`}
+      title={`Are you sure you want to delete ${selection.size} missing file${
+        selection.size > 1 ? 's' : ''
+      }?`}
       information="Deleting files will permanently remove them from Allusion. Accidentially moved files can be recovered by returning them to their previous location."
       onCancel={uiStore.closeToolbarFileRemover}
       onConfirm={handleConfirm}

--- a/src/frontend/containers/AppToolbar/SecondaryCommands.tsx
+++ b/src/frontend/containers/AppToolbar/SecondaryCommands.tsx
@@ -37,7 +37,11 @@ const SecondaryCommands = observer(({ uiStore }: { uiStore: UiStore }) => {
       <MenuItem
         icon={IconSet.LOGO}
         // TODO: Maybe add as native menu option (mac-os?)
-        onClick={() => window.alert('TODO: This application was made by [us]. It\'s open source. You can contribute here if you wanna [link]')}
+        onClick={() =>
+          window.alert(
+            'TODO: This application was made by [us]. It\'s open source. You can contribute here if you wanna [link]',
+          )
+        }
         text="About"
       />
     </MenuButton>

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -103,6 +103,7 @@ export const MasonryCell = observer(
     fileStore,
     forceNoThumbnail,
     transform: { height, width, left, top },
+    ...restProps
   }: IMasonryCell & React.HTMLAttributes<HTMLDivElement>) => {
     const style = { height, width, transform: `translate(${left}px,${top}px)` };
     return (
@@ -112,6 +113,7 @@ export const MasonryCell = observer(
         tabIndex={-1}
         aria-selected={uiStore.fileSelection.has(file)}
         style={style}
+        {...restProps}
       >
         <div className={`thumbnail${file.isBroken ? ' thumbnail-broken' : ''}`}>
           <Thumbnail

--- a/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
@@ -1,9 +1,18 @@
 import { observer } from 'mobx-react-lite';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { ViewMethod } from 'src/frontend/stores/UiStore';
-import { getThumbnailSize, ILayoutProps } from '../Gallery';
+import {
+  getThumbnailSize,
+  ILayoutProps,
+  onDrop,
+  onDragStart,
+  handleDragEnter,
+  handleDragOver,
+  handleDragLeave,
+} from '../Gallery';
 import { MasonryWorkerAdapter } from './MasonryWorkerAdapter';
 import VirtualizedRenderer from './VirtualizedRenderer';
+import { DnDType } from '../../Outliner/TagsPanel/dnd';
 
 interface IMasonryRendererProps {
   type: ViewMethod.MasonryVertical | ViewMethod.MasonryHorizontal;
@@ -104,6 +113,24 @@ const MasonryRenderer = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [containerWidth, thumbnailSize, viewMethod]);
 
+    const handleDragStart = useCallback(
+      (e: React.DragEvent<HTMLElement>, index: number) => {
+        if (e.dataTransfer.types.includes(DnDType)) {
+          onDragStart(e, index, uiStore, fileStore.fileList);
+        }
+      },
+      [fileStore.fileList, uiStore],
+    );
+
+    const handleDrop = useCallback(
+      (e: React.DragEvent<HTMLElement>, index: number) => {
+        if (e.dataTransfer.types.includes(DnDType)) {
+          onDrop(e, index, uiStore, fileStore.fileList);
+        }
+      },
+      [fileStore.fileList, uiStore],
+    );
+
     return !(containerHeight && layoutTimestamp) ? (
       <p>loading...</p>
     ) : (
@@ -120,6 +147,11 @@ const MasonryRenderer = observer(
         showContextMenu={showContextMenu}
         lastSelectionIndex={lastSelectionIndex}
         layoutUpdateDate={layoutTimestamp}
+        onDrop={handleDrop}
+        onDragStart={handleDragStart}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
       />
     );
   },

--- a/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.test.ts
+++ b/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.test.ts
@@ -1,4 +1,4 @@
-import { binarySearch, Layouter } from './renderer-helpers';
+import { findViewportEdge, Layouter } from './layout-helpers';
 
 // Simple linear layout: One image per row
 const linearLayout: Layouter = {
@@ -24,21 +24,21 @@ describe('masonry > renderer', () => {
   describe('binarySearch', () => {
     describe('linear layout', () => {
       it('should return 0 when viewport is at the top', () => {
-        const index = binarySearch(0, 10, linearLayout, false);
+        const index = findViewportEdge(0, 10, linearLayout, false);
         expect(index).toBe(0);
       });
       it('should correctly find the second image at height 15', () => {
-        const index = binarySearch(15, 10, linearLayout, false);
+        const index = findViewportEdge(15, 10, linearLayout, false);
         expect(index).toBe(1);
       });
       it('should correctly find the last image at max height', () => {
-        const index = binarySearch(999, 10, linearLayout, false);
+        const index = findViewportEdge(999, 10, linearLayout, false);
         expect(index).toBe(9);
       });
     });
     describe('dynamic layout', () => {
       it('should return 0 when viewport is at the top', () => {
-        const index = binarySearch(0, 10, dynamicLayout, false);
+        const index = findViewportEdge(0, 10, dynamicLayout, false);
         expect(index).toBe(0);
       });
       // TODO: More tests, after implementing over/under-shooting

--- a/src/frontend/containers/ContentView/Masonry/layout-helpers.ts
+++ b/src/frontend/containers/ContentView/Masonry/layout-helpers.ts
@@ -13,7 +13,7 @@ export interface Layouter {
  * @param layout The layout of the images
  * @param overshoot Whether to overshoot: return the first or last image at the specified height
  */
-export function binarySearch(
+export function findViewportEdge(
   height: number,
   length: number,
   layout: Layouter,

--- a/src/frontend/containers/ContentView/Placeholder.tsx
+++ b/src/frontend/containers/ContentView/Placeholder.tsx
@@ -6,7 +6,8 @@ import StoreContext from '../../contexts/StoreContext';
 const Placeholder = observer(() => {
   const { fileStore, tagStore, uiStore } = useContext(StoreContext);
 
-  if (fileStore.showsAllContent && tagStore.tagList.length === 1) { // 1 tag: the root tag
+  if (fileStore.showsAllContent && tagStore.tagList.length === 1) {
+    // 1 tag: the root tag
     // No tags exist, and no images added: Assuming it's a new user -> Show a welcome screen
     return <Welcome />;
   } else if (fileStore.showsAllContent) {
@@ -54,7 +55,6 @@ const Welcome = () => {
 
       {/* Mention principles (?) */}
       <small>Allusion is a read-only application. We'll never touch your files</small>
-
     </ContentPlaceholder>
   );
 };

--- a/src/frontend/containers/Outliner/LocationsPanel/dnd.ts
+++ b/src/frontend/containers/Outliner/LocationsPanel/dnd.ts
@@ -8,7 +8,8 @@ import { DnDAttribute } from '../TagsPanel/dnd';
 
 const ALLOWED_FILE_DROP_TYPES = IMG_EXTENSIONS.map((ext) => `image/${ext}`);
 
-export const isAcceptableType = (e: React.DragEvent) => e.dataTransfer?.types.some(type => ALLOWED_DROP_TYPES.includes(type));
+export const isAcceptableType = (e: React.DragEvent) =>
+  e.dataTransfer?.types.some((type) => ALLOWED_DROP_TYPES.includes(type));
 
 /**
  * Executed callback function while dragging over a target.
@@ -16,9 +17,7 @@ export const isAcceptableType = (e: React.DragEvent) => e.dataTransfer?.types.so
  * Do not pass an expansive function into the sideEffect parameter. The dragOver
  * event is fired constantly unlike dragEnter which is only fired once.
  */
-export function onDragOver(
-  event: React.DragEvent<HTMLDivElement>
-): boolean {
+export function onDragOver(event: React.DragEvent<HTMLDivElement>): boolean {
   const dropTarget = event.currentTarget;
 
   const isFile = isAcceptableType(event);

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -138,7 +138,6 @@ const Settings = observer(({ uiStore, fileStore }: ISettingsProps) => {
             <Button styling="filled" text="Browse" onClick={browseThumbnailDirectory} />
           </div>
         </fieldset>
-
       </div>
 
       <h2>Shortcuts Map</h2>


### PR DESCRIPTION
- Drag tags onto a selected file to apply the tag to all selected files. Not the most clean approach but it works. The yellow indicator on all selected items sometimes disappears when quickly dragging in between files though
- Added drag-tag support to masonry view

![allusion-tag-drag-mult-file](https://user-images.githubusercontent.com/5946427/107858711-f359c200-6e35-11eb-99cf-74e566c307e9.gif)
