### PR TITLE
Rc3 fixes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,9 +9,5 @@ module.exports = {
     'ts-jest': {
       tsconfig: 'tsconfig.jest.json',
     },
-    'self': {
-      // Fix for dexie-import-export error "ReferenceError: self is not defined"
-      value: () => window,
-    },
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,12 +1,17 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  modulePaths: ['<rootDir>'],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.jest.json',
+    },
+    'self': {
+      // Fix for dexie-import-export error "ReferenceError: self is not defined"
+      value: () => window,
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
       ]
     },
     "win": {
-      "target": ["nsis", "portable"],
+      "target": [
+        "nsis",
+        "portable"
+      ],
       "extraResources": [
         "resources/exiftool/exiftool.exe",
         "resources/exiftool/.Exiftool_config"
@@ -114,6 +117,7 @@
     "chokidar": "^3.5.1",
     "comlink": "^4.3.0",
     "dexie": "^3.0.3",
+    "dexie-export-import": "^1.0.0",
     "electron-updater": "^4.3.8",
     "fs-extra": "^9.1.0",
     "image-size": "^0.9.7",

--- a/resources/style/help-center.scss
+++ b/resources/style/help-center.scss
@@ -23,21 +23,14 @@
     }
   }
 
-  ul {
-    padding: 0;
-    list-style: none;
-    margin: 0;
-  }
-
-  li {
-    padding: 0.25rem 2rem 0.5rem;
-  }
-
   a {
+    display: block;
+    padding: 0.25rem 2rem 0.5rem;
     color: var(--text-color);
     text-decoration: none;
 
-    &:hover {
+    &:hover,
+    &:active {
       text-decoration: underline;
     }
   }
@@ -79,7 +72,7 @@
     margin-top: 0;
   }
 
-  > * {
+  section {
     margin: auto;
     max-width: 85ch;
   }

--- a/resources/style/help-center.scss
+++ b/resources/style/help-center.scss
@@ -33,10 +33,13 @@
     padding: 0.25rem 2rem 0.5rem;
   }
 
-  a:hover {
-    color: var(--accent-color-blue);
-    transition: color 0.2s $pt-transition-cubic2;
-    cursor: pointer;
+  a {
+    color: var(--text-color);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 

--- a/resources/style/remake/about.scss
+++ b/resources/style/remake/about.scss
@@ -1,0 +1,33 @@
+#about {
+  width: 100vw;
+  height: 100vh;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  > * {
+    max-width: 60ch;
+  }
+
+  img {
+    max-width: 150px;
+    border-radius: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    text-align: center;
+  }
+
+  a {
+    font-size: medium;
+    display: inline-block;
+    color: var(--text-color);
+  }
+
+  ul {
+    line-height: 1rem;
+  }
+}

--- a/resources/style/remake/global.scss
+++ b/resources/style/remake/global.scss
@@ -52,9 +52,8 @@ fieldset {
 }
 
 label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  margin-bottom: 0.25rem;
 }
 
 input {
@@ -76,8 +75,8 @@ select {
   border: 0.0625rem solid var(--border-color);
   outline: none;
   border-radius: 0.25rem;
-  margin: 0.125rem 0.25rem;
   line-height: 1.5rem;
+  min-height: 1.5rem;
 
   &:hover {
     background: var(--input-color-hover);

--- a/resources/style/remake/layout.scss
+++ b/resources/style/remake/layout.scss
@@ -36,37 +36,6 @@ body {
   right: 0;
 }
 
-#about {
-  width: 100vw;
-  height: 100vh;
-  padding: 1rem;
-  text-align: center;
-  .centered {
-    max-width: 60%;
-    min-width: 400px;
-    margin: auto;
-  }
-  img {
-    max-width: 170px;
-    border-radius: 0.75rem;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
-    display: flex;
-    margin: auto;
-  }
-  #version {
-    margin-bottom: 0.2rem;
-  }
-  ul {
-    text-align: initial;
-    max-width: 270px;
-    margin: auto;
-    li {
-      margin-bottom: 2px;
-    }
-  }
-}
-
 #main {
   position: relative;
 }

--- a/resources/style/settings.scss
+++ b/resources/style/settings.scss
@@ -1,9 +1,5 @@
 #settings {
   background-color: var(--background-color);
-
-  #hierarchical-separator select {
-    min-width: 2.5rem;
-  }
 }
 
 .key-combo-editor {

--- a/resources/style/settings.scss
+++ b/resources/style/settings.scss
@@ -1,11 +1,6 @@
 #settings {
   background-color: var(--background-color);
 
-  .toggle,
-  #hierarchical-separator {
-    justify-content: space-between;
-  }
-
   #hierarchical-separator select {
     min-width: 2.5rem;
   }
@@ -13,7 +8,8 @@
 
 .key-combo-editor {
   display: flex;
-  padding: 0.5rem;
+  align-items: center;
+  margin-left: 0.5rem;
 }
 
 .key-combo-input {
@@ -23,12 +19,6 @@
 .key-combo-input-warning {
   display: flex;
   padding: 0.25rem;
-}
-
-.zoom-widget {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 }
 
 // Zoom factor text

--- a/src/backend/Backend.test.ts
+++ b/src/backend/Backend.test.ts
@@ -34,7 +34,7 @@ const mockFile: IFile = {
 
 describe('Backend', () => {
   beforeAll(() => {
-    return backend.init(false);
+    return backend.init(true);
   });
 
   describe('Tag API', () => {

--- a/src/backend/Backend.test.ts
+++ b/src/backend/Backend.test.ts
@@ -34,7 +34,7 @@ const mockFile: IFile = {
 
 describe('Backend', () => {
   beforeAll(() => {
-    return backend.init();
+    return backend.init(false);
   });
 
   describe('Tag API', () => {

--- a/src/backend/BackupScheduler.ts
+++ b/src/backend/BackupScheduler.ts
@@ -1,0 +1,102 @@
+import fse from 'fs-extra';
+import path from 'path';
+import { debounce } from 'src/frontend/utils';
+
+import Backend from './Backend';
+import { NUM_AUTO_BACKUPS, AUTO_BACKUP_TIMEOUT } from './config';
+
+/** Returns the date at 00:00 today */
+function getToday(): Date {
+  const today = new Date();
+  today.setHours(0);
+  today.setMinutes(0);
+  today.setSeconds(0, 0);
+  return today;
+}
+
+/** Returns the date at the start of the current week (Sunday at 00:00) */
+function getWeekStart(): Date {
+  const date = getToday();
+  const dayOfWeek = date.getDay();
+  date.setDate(date.getDate() - dayOfWeek);
+  return date;
+}
+
+export default class BackupScheduler {
+  private lastBackupIndex: number = 0;
+  private lastBackupDate: Date = new Date(0);
+  private backupDirectory: string = '';
+
+  private debouncedCreatePeriodicBackup: () => Promise<void>;
+
+  constructor(private backend: Backend) {
+    // Wait 10 seconds after a change for any other changes before creating a backup
+    this.debouncedCreatePeriodicBackup = debounce(this.createPeriodicBackup, 10000).bind(this);
+  }
+
+  async initialize(backupDirectory: string): Promise<void> {
+    this.backupDirectory = backupDirectory;
+    await fse.ensureDir(this.backupDirectory);
+  }
+
+  /** Creates a copy of a backup file, when the target file creation date is less than the provided date */
+  private static async copyFileIfCreatedBeforeDate(
+    srcPath: string,
+    targetPath: string,
+    dateToCheck: Date,
+  ): Promise<boolean> {
+    let createBackup = false;
+    try {
+      // If file creation date is less than provided date, create a back-up
+      const stats = await fse.stat(targetPath);
+      createBackup = stats.ctime < dateToCheck;
+    } catch (e) {
+      // File not found
+      createBackup = true;
+    }
+    if (createBackup) {
+      try {
+        await fse.copyFile(srcPath, targetPath);
+        console.log('Created backup', targetPath);
+        return true;
+      } catch (e) {
+        console.error('Could not create backup', targetPath, e);
+      }
+    }
+    return false;
+  }
+
+  private async createPeriodicBackup() {
+    const filePath = path.join(this.backupDirectory, `auto-backup-${this.lastBackupIndex}.json`);
+
+    this.lastBackupDate = new Date();
+    this.lastBackupIndex = (this.lastBackupIndex + 1) % NUM_AUTO_BACKUPS;
+
+    try {
+      await this.backend.backupDatabaseToFile(filePath);
+      console.log('Created automatic backup', filePath);
+
+      // Check for daily backup
+      await BackupScheduler.copyFileIfCreatedBeforeDate(
+        filePath,
+        path.join(this.backupDirectory, 'daily.json'),
+        getToday(),
+      );
+
+      // Check for weekly backup
+      await BackupScheduler.copyFileIfCreatedBeforeDate(
+        filePath,
+        path.join(this.backupDirectory, 'weekly.json'),
+        getWeekStart(),
+      );
+    } catch (e) {
+      console.error('Could not create periodic backup', filePath, e);
+    }
+  }
+
+  notifyChange(): void {
+    if (new Date().getTime() > this.lastBackupDate.getTime() + AUTO_BACKUP_TIMEOUT) {
+      this.debouncedCreatePeriodicBackup();
+    }
+  }
+}

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -3,6 +3,10 @@ import { IDBVersioningConfig } from './DBRepository';
 // The name of the IndexedDB
 export const DB_NAME = 'Allusion';
 
+export const NUM_AUTO_BACKUPS = 6;
+
+export const AUTO_BACKUP_TIMEOUT = 1000 * 60 * 10; // 10 minutes
+
 // Schema based on https://dexie.org/docs/Version/Version.stores()#schema-syntax
 // Only for the indexes of the DB, not all fields
 // Versions help with upgrading DB to new configurations:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+import { RendererMessenger } from './Messaging';
+
 export function isDev() {
   return process.env.NODE_ENV === 'development';
 }
@@ -20,3 +23,13 @@ const isRenderer = process && process.type === 'renderer';
 // A value of 1 indicates a classic 96 DPI (76 DPI on some platforms) display, while a value of 2 is expected for HiDPI/Retina displays.
 // The values 600 : 400 needed to be flipped in order to get 600 on OSX Retina
 export const thumbnailMaxSize = isRenderer && window.devicePixelRatio >= 1.5 ? 400 : 600;
+
+export async function getDefaultThumbnailDirectory() {
+  const userDataPath = await RendererMessenger.getPath('temp');
+  return path.join(userDataPath, 'Allusion', 'thumbnails');
+}
+
+export async function getDefaultBackupDirectory() {
+  const userDataPath = await RendererMessenger.getPath('userData');
+  return path.join(userDataPath, 'backups');
+}

--- a/src/frontend/Preview.tsx
+++ b/src/frontend/Preview.tsx
@@ -47,9 +47,10 @@ const PreviewApp = observer(() => {
             disabled={uiStore.firstItem === fileStore.fileList.length - 1}
           />
           <Toggle
-            label="Overview"
             onChange={uiStore.toggleSlideMode}
             checked={!uiStore.isSlideMode}
+            onLabel="Overview"
+            offLabel="Details"
           />
         </Toolbar>
 

--- a/src/frontend/containers/About.tsx
+++ b/src/frontend/containers/About.tsx
@@ -21,39 +21,35 @@ const About = observer(() => {
   return (
     <PopupWindow onClose={uiStore.closeAbout} windowName="about" closeOnEscape>
       <div id="about" className="light">
-        <div className="centered">
-          <img src={Logo_About} alt="Logo" />
-          <small>
-            Version <strong>{RendererMessenger.getVersion()}</strong>
-          </small>
-          <p>
-            This application was made by a small team of individuals who gathered due to common
-            interest in art, design and software.
-            <br />
-            It&apos;s completely <b>free and open source</b>! Find out more:
-          </p>
-          <h3>
-            <a href="https://allusion-app.github.io/" onClick={clickLink}>
-              allusion-app.github.io
-            </a>
-          </h3>
-          <ul>
-            <li>General information</li>
-            <li>Download the latest version</li>
-          </ul>
-          <h3>
-            <a href="https://github.com/allusion-app/Allusion" onClick={clickLink}>
-              github.com/allusion-app/Allusion
-            </a>
-          </h3>
-          <ul>
-            <li>🤓 View the source code</li>
-            <li>🐛 Provide feedback and report bugs</li>
-            <li>👥 Learn about contributing</li>
-          </ul>
+        <img src={Logo_About} alt="Logo" />
+        <small>
+          Version <strong>{RendererMessenger.getVersion()}</strong>
+        </small>
+        <p>
+          This application was made by a small team of individuals who gathered due to common
+          interest in art, design and software.
           <br />
-          {/* TODO: Licensing info here? */}
-        </div>
+          It&apos;s completely <b>free and open source</b>! Find out more at
+        </p>
+        <span>
+          <a href="https://allusion-app.github.io/" onClick={clickLink}>
+            allusion-app.github.io
+          </a>
+          .
+        </span>
+        <ul>
+          <li>General information</li>
+          <li>Download the latest version</li>
+        </ul>
+        <a href="https://github.com/allusion-app/Allusion" onClick={clickLink}>
+          github.com/allusion-app/Allusion
+        </a>
+        <ul>
+          <li>🤓 View the source code</li>
+          <li>🐛 Provide feedback and report bugs</li>
+          <li>👥 Learn about contributing</li>
+        </ul>
+        {/* TODO: Licensing info here? */}
       </div>
     </PopupWindow>
   );

--- a/src/frontend/containers/AdvancedSearch/Field.tsx
+++ b/src/frontend/containers/AdvancedSearch/Field.tsx
@@ -27,23 +27,21 @@ interface IFieldProps {
 
 // The main Criteria component, finds whatever input fields for the key should be rendered
 export const Field = ({ id, query, dispatch, removable }: IFieldProps) => (
-  <fieldset>
-    <div className="criteria">
-      <KeySelector id={id} keyValue={query.key} dispatch={dispatch} />
-      <OperatorSelector id={id} keyValue={query.key} value={query.operator} dispatch={dispatch} />
-      <ValueInput id={id} keyValue={query.key} value={query.value} dispatch={dispatch} />
-      <IconButton
-        text="Remove search item"
-        icon={IconSet.DELETE}
-        onClick={() =>
-          dispatch((form) => {
-            form.delete(id);
-            return new Map(form);
-          })
-        }
-        disabled={!removable}
-      />
-    </div>
+  <fieldset className="criteria">
+    <KeySelector id={id} keyValue={query.key} dispatch={dispatch} />
+    <OperatorSelector id={id} keyValue={query.key} value={query.operator} dispatch={dispatch} />
+    <ValueInput id={id} keyValue={query.key} value={query.value} dispatch={dispatch} />
+    <IconButton
+      text="Remove search item"
+      icon={IconSet.DELETE}
+      onClick={() =>
+        dispatch((form) => {
+          form.delete(id);
+          return new Map(form);
+        })
+      }
+      disabled={!removable}
+    />
   </fieldset>
 );
 

--- a/src/frontend/containers/AdvancedSearch/Field.tsx
+++ b/src/frontend/containers/AdvancedSearch/Field.tsx
@@ -214,30 +214,22 @@ const DateAddedInput = ({ value, id, dispatch }: ValueInput<Date>) => {
 
 function getOperatorOptions(key: QueryKey) {
   if (key === 'dateAdded' || key === 'size') {
-    return OperatorOptions.NUMBER;
+    return NumberOperators.map(toOperatorOption);
   } else if (key === 'extension') {
-    return OperatorOptions.BINARY;
+    return BinaryOperators.map(toOperatorOption);
   } else if (key === 'name' || key === 'absolutePath') {
-    return OperatorOptions.STRING;
+    return StringOperators.map(toOperatorOption);
   } else if (key === 'tags') {
-    return OperatorOptions.TAG;
+    return TagOperators.map(toOperatorOption);
   }
   return [];
 }
 
-const OperatorOptions = (function () {
-  const toOption = (o: string) => (
-    <option key={o} value={o}>
-      {camelCaseToSpaced(o)}
-    </option>
-  );
-  return {
-    TAG: TagOperators.map(toOption),
-    BINARY: BinaryOperators.map(toOption),
-    NUMBER: NumberOperators.map(toOption),
-    STRING: StringOperators.map(toOption),
-  };
-})();
+const toOperatorOption = (o: string) => (
+  <option key={o} value={o}>
+    {camelCaseToSpaced(o)}
+  </option>
+);
 
 function setValue(id: ID, value: QueryValue): (form: FormState) => FormState {
   return (form: FormState) => {

--- a/src/frontend/containers/AdvancedSearch/search.scss
+++ b/src/frontend/containers/AdvancedSearch/search.scss
@@ -1,29 +1,25 @@
 #search-form {
-  fieldset {
-    margin-bottom: 0.25rem;
-  }
   .criteria {
+    padding: 2px;
+    margin-bottom: 0.25rem;
     display: flex;
     align-items: center;
 
-    > * {
+    > :not(.btn) {
       flex-grow: 1;
+      margin-right: 0.5rem;
+      max-width: 25%;
     }
 
-    > select:not(:nth-child(3)) {
-      max-width: 25%;
+    > :nth-child(3) {
+      max-width: none;
+      margin-right: 0.25rem;
     }
 
     > .btn {
       flex-grow: 0;
       height: 1.5rem;
       width: 1.5rem;
-    }
-
-    .multiautocomplete-input {
-      input {
-        width: 0; // for it to align with other criteria types
-      }
     }
   }
 }
@@ -32,21 +28,22 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
 
-  > fieldset {
-    margin: 0 !important;
+  [role='radiogroup'] {
     > div {
-      display: flex;
+      flex-direction: row;
       align-items: center;
+    }
 
-      legend {
-        color: var(--text-color);
-        margin: 0;
-        margin-right: 1.5rem;
-      }
-      label {
-        margin: 0;
+    legend {
+      margin: 0;
+      margin-right: 1.5rem;
+    }
+
+    label {
+      margin: 0;
+
+      &:first-of-type {
         margin-right: 1rem;
       }
     }

--- a/src/frontend/containers/AppToolbar/Menus.tsx
+++ b/src/frontend/containers/AppToolbar/Menus.tsx
@@ -50,6 +50,7 @@ export const ViewCommand = ({ uiStore }: { uiStore: UiStore }) => {
 const sortMenuData: Array<{ prop: keyof IFile; icon: JSX.Element; text: string }> = [
   // { prop: 'tags', icon: IconSet.TAG, text: 'Tag' },
   { prop: 'name', icon: IconSet.FILTER_NAME_UP, text: 'Name' },
+  { prop: 'absolutePath', icon: IconSet.FOLDER_OPEN, text: 'Path' },
   { prop: 'extension', icon: IconSet.FILTER_FILE_TYPE, text: 'File type' },
   { prop: 'size', icon: IconSet.FILTER_FILTER_DOWN, text: 'File size' },
   { prop: 'dateAdded', icon: IconSet.FILTER_DATE, text: 'Date added' },

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -28,7 +28,9 @@ export const FileViewerMenuItems = ({ file, uiStore }: { file: ClientFile; uiSto
   };
 
   const handlePreviewWindow = () => {
-    uiStore.selectFile(file, true);
+    if (!uiStore.fileSelection.has(file)) {
+      uiStore.selectFile(file, true);
+    }
     uiStore.openPreviewWindow();
   };
 

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -72,7 +72,7 @@ export const SlideFileViewerMenuItems = ({
 export const ExternalAppMenuItems = ({ file }: { file: ClientFile }) => (
   <>
     <MenuItem
-      onClick={() => shell.openExternal(file.absolutePath)}
+      onClick={() => shell.openExternal(`file://${file.absolutePath}`).catch(console.error)}
       text="Open External"
       icon={IconSet.OPEN_EXTERNAL}
       disabled={file.isBroken}

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -28,9 +28,8 @@ export const FileViewerMenuItems = ({ file, uiStore }: { file: ClientFile; uiSto
   };
 
   const handlePreviewWindow = () => {
-    if (!uiStore.fileSelection.has(file)) {
-      uiStore.selectFile(file, true);
-    }
+    // Only clear selection if file is not already selected
+    uiStore.selectFile(file, !uiStore.fileSelection.has(file));
     uiStore.openPreviewWindow();
   };
 

--- a/src/frontend/containers/HelpCenter.tsx
+++ b/src/frontend/containers/HelpCenter.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unescaped-entities */
-import React, { useCallback, useContext, useEffect, useRef, useState, memo } from 'react';
+import React, { useCallback, useContext, useRef, useState, memo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { Button, ButtonGroup, IconSet, Split } from 'widgets';
 import Logo_About from 'resources/images/helpcenter/logo-about-helpcenter-dark.jpg';
@@ -41,13 +41,7 @@ interface IDocumentation {
 
 const Documentation = ({ id, overviewId, className, initPages }: IDocumentation) => {
   const [pageIndex, setPageIndex] = useState(0);
-  const [sectionIndex, setSectionIndex] = useState(0);
   const data = useRef(initPages());
-
-  const openPage = useRef((page: number, section: number) => {
-    setPageIndex(page);
-    setSectionIndex(section);
-  });
 
   const [isIndexOpen, setIndexIsOpen] = useState(true);
   const toggleIndex = useRef(() => setIndexIsOpen((value) => !value));
@@ -72,7 +66,7 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
   return (
     <div id={id} className={className}>
       <Split
-        primary={<Overview id={overviewId} pages={data.current} openPage={openPage.current} />}
+        primary={<Overview id={overviewId} pages={data.current} openPage={setPageIndex} />}
         secondary={
           <Page
             toolbar={
@@ -83,9 +77,8 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
               />
             }
             pages={data.current}
-            openPage={openPage.current}
+            openPage={setPageIndex}
             pageIndex={pageIndex}
-            sectionIndex={sectionIndex}
           />
         }
         axis="vertical"
@@ -101,7 +94,7 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
 interface IOverview {
   id: string;
   pages: IPageData[];
-  openPage: (page: number, section: number) => void;
+  openPage: (page: number) => void;
 }
 
 const Overview = memo(function Overview({ id, pages, openPage }: IOverview) {
@@ -114,9 +107,14 @@ const Overview = memo(function Overview({ id, pages, openPage }: IOverview) {
             {page.title}
           </summary>
           <ul>
-            {page.sections.map((section, sectionIndex) => (
+            {page.sections.map((section) => (
               <li key={section.title}>
-                <a onClick={() => openPage(pageIndex, sectionIndex)}>{section.title}</a>
+                <a
+                  href={`#${section.title.toLowerCase().replaceAll(' ', '-')}`}
+                  onClick={() => openPage(pageIndex)}
+                >
+                  {section.title}
+                </a>
               </li>
             ))}
           </ul>
@@ -130,39 +128,30 @@ interface IPage {
   toolbar: React.ReactNode;
   pages: IPageData[];
   pageIndex: number;
-  sectionIndex: number;
-  openPage: (page: number, section: number) => void;
+  openPage: (page: number) => void;
 }
 
 const Page = (props: IPage) => {
-  const { toolbar, pages, pageIndex, sectionIndex, openPage } = props;
-  const page = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    if (page.current !== null) {
-      const section = page.current.children[sectionIndex];
-      section.scrollIntoView();
-    }
-  }, [sectionIndex, pageIndex]);
+  const { toolbar, pages, pageIndex, openPage } = props;
 
   const buttons = [];
   if (pageIndex > 0) {
-    const previousPage = () => openPage(pageIndex - 1, 0);
+    const previousPage = () => openPage(pageIndex - 1);
     buttons.push(
       <Button key="previous" styling="outlined" onClick={previousPage} text="Previous" />,
     );
   }
   if (pageIndex < pages.length - 1) {
-    const nextPage = () => openPage(pageIndex + 1, 0);
+    const nextPage = () => openPage(pageIndex + 1);
     buttons.push(<Button key="next" styling="outlined" onClick={nextPage} text="Next" />);
   }
 
   return (
     <div className="doc-page">
       {toolbar}
-      <article className="doc-page-content" ref={page}>
+      <article className="doc-page-content">
         {pages[pageIndex].sections.map((section) => (
-          <section key={section.title}>
+          <section id={section.title.toLowerCase().replaceAll(' ', '-')} key={section.title}>
             <h2>{section.title}</h2>
             {section.content}
           </section>

--- a/src/frontend/containers/HelpCenter.tsx
+++ b/src/frontend/containers/HelpCenter.tsx
@@ -44,7 +44,6 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
   const data = useRef(initPages());
 
   const [isIndexOpen, setIndexIsOpen] = useState(true);
-  const toggleIndex = useRef(() => setIndexIsOpen((value) => !value));
   const [splitPoint, setSplitPoint] = useState(224); // 14rem
   const handleMove = useCallback(
     (x: number, width: number) => {
@@ -72,7 +71,7 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
             toolbar={
               <PageToolbar
                 isIndexOpen={isIndexOpen}
-                toggleIndex={toggleIndex.current}
+                toggleIndex={setIndexIsOpen}
                 controls={overviewId}
               />
             }
@@ -106,18 +105,15 @@ const Overview = memo(function Overview({ id, pages, openPage }: IOverview) {
             {page.icon}
             {page.title}
           </summary>
-          <ul>
-            {page.sections.map((section) => (
-              <li key={section.title}>
-                <a
-                  href={`#${section.title.toLowerCase().replaceAll(' ', '-')}`}
-                  onClick={() => openPage(pageIndex)}
-                >
-                  {section.title}
-                </a>
-              </li>
-            ))}
-          </ul>
+          {page.sections.map((section) => (
+            <a
+              key={section.title}
+              href={`#${section.title.toLowerCase().replaceAll(' ', '-')}`}
+              onClick={() => openPage(pageIndex)}
+            >
+              {section.title}
+            </a>
+          ))}
         </details>
       ))}
     </nav>
@@ -164,7 +160,7 @@ const Page = (props: IPage) => {
 
 interface IPageToolbar {
   isIndexOpen: boolean;
-  toggleIndex: () => void;
+  toggleIndex: React.Dispatch<React.SetStateAction<boolean>>;
   controls: string;
 }
 
@@ -175,7 +171,7 @@ const PageToolbar = ({ isIndexOpen, toggleIndex, controls }: IPageToolbar) => {
         className="btn toolbar-button"
         aria-pressed={isIndexOpen}
         aria-controls={controls}
-        onClick={toggleIndex}
+        onClick={() => toggleIndex((value) => !value)}
         tabIndex={0}
       >
         <span className="btn-content-icon" aria-hidden="true">

--- a/src/frontend/containers/HelpCenter.tsx
+++ b/src/frontend/containers/HelpCenter.tsx
@@ -41,7 +41,7 @@ interface IDocumentation {
 
 const Documentation = ({ id, overviewId, className, initPages }: IDocumentation) => {
   const [pageIndex, setPageIndex] = useState(0);
-  const data = useRef(initPages());
+  const pages = useRef(initPages()).current;
 
   const [isIndexOpen, setIndexIsOpen] = useState(true);
   const [splitPoint, setSplitPoint] = useState(224); // 14rem
@@ -65,7 +65,7 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
   return (
     <div id={id} className={className}>
       <Split
-        primary={<Overview id={overviewId} pages={data.current} openPage={setPageIndex} />}
+        primary={<Overview id={overviewId} pages={pages} openPage={setPageIndex} />}
         secondary={
           <Page
             toolbar={
@@ -75,7 +75,7 @@ const Documentation = ({ id, overviewId, className, initPages }: IDocumentation)
                 controls={overviewId}
               />
             }
-            pages={data.current}
+            pages={pages}
             openPage={setPageIndex}
             pageIndex={pageIndex}
           />

--- a/src/frontend/containers/Settings/Tabs.tsx
+++ b/src/frontend/containers/Settings/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
 
 export type TabItem = {
   label: string;
@@ -6,11 +6,12 @@ export type TabItem = {
 };
 
 interface ITabs {
-  items: TabItem[];
+  initTabItems: () => TabItem[];
 }
 
-const Tabs = ({ items }: ITabs) => {
+const Tabs = ({ initTabItems }: ITabs) => {
   const [selection, setSelection] = useState(0);
+  const items = useRef(initTabItems()).current;
 
   return (
     <div className="tabs">

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -177,12 +177,12 @@ const ImportExport = observer(() => {
       <h2>Import/Export</h2>
 
       <h3>File Metadata</h3>
+
       <Callout icon={IconSet.INFO}>
         This option is useful for importing/exporting tags from/to other software, or when you use
-        Allusion for images on multiple devices synchronized using a service such as Dropbox or
-        Google Drive.
+        Allusion on multiple devices and want to synchronize the data using a service such as
+        Dropbox or Google Drive.
       </Callout>
-
       <label id="hierarchical-separator">
         <span>
           Hierarchical separator, e.g.{' '}
@@ -230,22 +230,18 @@ const ImportExport = observer(() => {
 
       <h3>Backup Database as File</h3>
 
-      <Callout icon={IconSet.INFO}>
-        Backups of Allusion&quot;s database are saved in the following directory.
-        <br />
-        Automatic back-ups are created every 10 minutes.
-      </Callout>
-
-      <div className="input-file">
-        <input readOnly className="input input-file-value" value={backupDir} />
-        <IconButton
-          icon={IconSet.FOLDER_CLOSE}
-          onClick={() => shell.showItemInFolder(backupDir)}
-          text="Open in file explorer"
-        />
-      </div>
-
-      <br />
+      <Callout icon={IconSet.INFO}>Automatic back-ups are created every 10 minutes.</Callout>
+      <fieldset>
+        <legend>Backup Directory</legend>
+        <div className="input-file">
+          <input readOnly className="input input-file-value" value={backupDir} />
+          <IconButton
+            icon={IconSet.FOLDER_CLOSE}
+            onClick={() => shell.showItemInFolder(backupDir)}
+            text="Open in file explorer"
+          />
+        </div>
+      </fieldset>
 
       <ButtonGroup>
         <Button

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -2,7 +2,7 @@ import { shell } from 'electron';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import SysPath from 'path';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   chromeExtensionUrl,
   getDefaultBackupDirectory,
@@ -22,8 +22,37 @@ import { ClearDbButton } from '../ErrorBoundary';
 import HotkeyMapper from './HotkeyMapper';
 import Tabs, { TabItem } from './Tabs';
 
+const Settings = () => {
+  const { uiStore } = useContext(StoreContext);
+
+  if (!uiStore.isSettingsOpen) {
+    return null;
+  }
+
+  return (
+    <PopupWindow
+      onClose={uiStore.closeSettings}
+      windowName="settings"
+      closeOnEscape
+      additionalCloseKey={uiStore.hotkeyMap.toggleSettings}
+    >
+      <div id="settings" className={uiStore.theme}>
+        <Tabs initTabItems={SETTINGS_TABS} />
+      </div>
+    </PopupWindow>
+  );
+};
+
+export default observer(Settings);
+
 const Appearance = observer(() => {
   const { uiStore } = useContext(StoreContext);
+
+  const toggleFullScreen = (e: React.FormEvent<HTMLInputElement>) => {
+    const isFullScreen = e.currentTarget.checked;
+    localStorage.setItem(WINDOW_STORAGE_KEY, JSON.stringify({ isFullScreen }));
+    RendererMessenger.setFullScreen(isFullScreen);
+  };
 
   return (
     <>
@@ -131,7 +160,7 @@ const ImportExport = observer(() => {
     getDefaultBackupDirectory().then(setBackupDir);
   }, []);
 
-  const handleChooseImportDir = useCallback(async () => {
+  const handleChooseImportDir = async () => {
     const { filePaths } = await RendererMessenger.openDialog({
       properties: ['openFile'],
       filters: [{ extensions: ['json'], name: 'JSON' }],
@@ -151,12 +180,11 @@ const ImportExport = observer(() => {
       console.log(e);
       AppToaster.show({ message: 'Backup file is invalid', timeout: 5000 });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [backupDir]);
+  };
 
-  const handleCreateExport = useCallback(async () => {
-    let filename = `backup_${getFilenameFriendlyFormattedDateTime(new Date())}.json`;
-    filename = filename.replaceAll(':', '-');
+  const handleCreateExport = async () => {
+    const formattedDateTime = getFilenameFriendlyFormattedDateTime(new Date());
+    const filename = `backup_${formattedDateTime}.json`.replaceAll(':', '-');
     const filepath = SysPath.join(backupDir, filename);
     try {
       await rootStore.backupDatabaseToFile(filepath);
@@ -173,7 +201,7 @@ const ImportExport = observer(() => {
         timeout: 5000,
       });
     }
-  }, [backupDir, rootStore]);
+  };
 
   return (
     <>
@@ -482,7 +510,7 @@ const Advanced = observer(() => {
   );
 });
 
-const SETTINGS_TABS: TabItem[] = [
+const SETTINGS_TABS: () => TabItem[] = () => [
   {
     label: 'Appearance',
     content: <Appearance />,
@@ -504,32 +532,3 @@ const SETTINGS_TABS: TabItem[] = [
     content: <Advanced />,
   },
 ];
-
-const Settings = () => {
-  const { uiStore } = useContext(StoreContext);
-
-  if (!uiStore.isSettingsOpen) {
-    return null;
-  }
-
-  return (
-    <PopupWindow
-      onClose={uiStore.closeSettings}
-      windowName="settings"
-      closeOnEscape
-      additionalCloseKey={uiStore.hotkeyMap.toggleSettings}
-    >
-      <div id="settings" className={uiStore.theme}>
-        <Tabs items={SETTINGS_TABS} />
-      </div>
-    </PopupWindow>
-  );
-};
-
-export default observer(Settings);
-
-const toggleFullScreen = (e: React.FormEvent<HTMLInputElement>) => {
-  const isFullScreen = e.currentTarget.checked;
-  localStorage.setItem(WINDOW_STORAGE_KEY, JSON.stringify({ isFullScreen }));
-  RendererMessenger.setFullScreen(isFullScreen);
-};

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -256,7 +256,6 @@ const BackgroundProcesses = observer(() => {
         </div>
       </fieldset>
 
-      {/* TODO: Link to chrome extension page when it's up */}
       <Button
         onClick={() => shell.openExternal(chromeExtensionUrl)}
         styling="outlined"

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -214,7 +214,7 @@ const ImportExport = observer(() => {
         service like Dropbox or Google, you can write your tags to your files on one device and read
         them on other devices.
       </Callout>
-      <fieldset id="hierarchical-separator">
+      <fieldset>
         <legend>
           Hierarchical separator, e.g.{' '}
           <pre style={{ display: 'inline' }}>

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -30,24 +30,27 @@ const Appearance = observer(() => {
       <h2>Appearance</h2>
 
       <h3>Interface</h3>
-      <Toggle
-        checked={uiStore.theme === 'dark'}
-        onChange={uiStore.toggleTheme}
-        label="Dark theme"
-      />
-      <Toggle
-        defaultChecked={uiStore.isFullScreen}
-        onChange={toggleFullScreen}
-        label="Full screen"
-      />
+      <fieldset>
+        <legend>Dark theme</legend>
+        <Toggle checked={uiStore.theme === 'dark'} onChange={uiStore.toggleTheme} />
+      </fieldset>
+
+      <fieldset>
+        <legend>Full screen</legend>
+        <Toggle checked={uiStore.isFullScreen} onChange={toggleFullScreen} />
+      </fieldset>
+
       <Zoom />
 
       <h3>Thumbnail</h3>
-      <Toggle
-        defaultChecked={uiStore.isThumbnailTagOverlayEnabled}
-        onChange={uiStore.toggleThumbnailTagOverlay}
-        label="Show assigned tags"
-      />
+      <fieldset>
+        <legend>Show assigned tags</legend>
+        <Toggle
+          checked={uiStore.isThumbnailTagOverlayEnabled}
+          onChange={uiStore.toggleThumbnailTagOverlay}
+        />
+      </fieldset>
+
       <div className="settings-thumbnail">
         <RadioGroup name="Size">
           <Radio
@@ -96,8 +99,8 @@ const Zoom = () => {
   }, [localZoomFactor]);
 
   return (
-    <div className="zoom-widget">
-      Zoom
+    <fieldset>
+      <legend>Zoom</legend>
       <span className="zoom-input">
         <IconButton
           icon={<span>-</span>}
@@ -111,7 +114,7 @@ const Zoom = () => {
           text="Zoom in"
         />
       </span>
-    </div>
+    </fieldset>
   );
 };
 
@@ -183,13 +186,13 @@ const ImportExport = observer(() => {
         service like Dropbox or Google, you can write your tags to your files on one device and read
         them on other devices.
       </Callout>
-      <label id="hierarchical-separator">
-        <span>
+      <fieldset id="hierarchical-separator">
+        <legend>
           Hierarchical separator, e.g.{' '}
           <pre style={{ display: 'inline' }}>
             {['Food', 'Fruit', 'Apple'].join(fileStore.exifTool.hierarchicalSeparator)}
           </pre>
-        </span>
+        </legend>
         <select
           value={fileStore.exifTool.hierarchicalSeparator}
           onChange={(e) => fileStore.exifTool.setHierarchicalSeparator(e.target.value)}
@@ -199,7 +202,7 @@ const ImportExport = observer(() => {
           <option value="\">\</option>
           <option value=":">:</option>
         </select>
-      </label>
+      </fieldset>
       {/* TODO: adobe bridge has option to read with multiple separators */}
 
       <ButtonGroup>
@@ -209,7 +212,7 @@ const ImportExport = observer(() => {
           styling="outlined"
         />
         <Button
-          text="Write tags to file metadata"
+          text="Export tags to file metadata"
           onClick={() => setConfirmingMetadataExport(true)}
           styling="outlined"
         />
@@ -235,17 +238,18 @@ const ImportExport = observer(() => {
         <legend>Backup Directory</legend>
         <div className="input-file">
           <input readOnly className="input input-file-value" value={backupDir} />
-          <IconButton
+          <Button
+            styling="minimal"
             icon={IconSet.FOLDER_CLOSE}
+            text="Open"
             onClick={() => shell.showItemInFolder(backupDir)}
-            text="Open in file explorer"
           />
         </div>
       </fieldset>
 
       <ButtonGroup>
         <Button
-          text="Restore database from file..."
+          text="Restore database from file"
           onClick={handleChooseImportDir}
           icon={IconSet.IMPORT}
           styling="outlined"
@@ -312,37 +316,46 @@ const BackgroundProcesses = observer(() => {
     }
   };
 
+  const [isRunInBackground, setRunInBackground] = useState(
+    RendererMessenger.isRunningInBackground(),
+  );
+  const toggleRunInBackground = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRunInBackground(e.target.checked);
+    RendererMessenger.setRunInBackground({ isRunInBackground: e.target.checked });
+  };
+
   const [isClipEnabled, setClipServerEnabled] = useState(RendererMessenger.isClipServerEnabled());
-  const handleSetClipServerEnabled = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const toggleClipServer = (e: React.ChangeEvent<HTMLInputElement>) => {
     setClipServerEnabled(e.target.checked);
-    toggleClipServer(e);
+    RendererMessenger.setClipServerEnabled({ isClipServerRunning: e.target.checked });
   };
 
   return (
     <>
       <h2>Options</h2>
-      <Toggle
-        defaultChecked={RendererMessenger.isRunningInBackground()}
-        onChange={toggleRunInBackground}
-        label="Run in background"
-      />
+      <fieldset>
+        <legend>Run in background</legend>
+        <Toggle checked={isRunInBackground} onChange={toggleRunInBackground} />
+      </fieldset>
 
-      <Toggle
-        checked={isClipEnabled}
-        onChange={
-          isClipEnabled || importDirectory
-            ? handleSetClipServerEnabled
-            : (e) => {
-                console.log('came here');
-                e.preventDefault();
-                e.stopPropagation();
-                alert(
-                  'Please choose a download directory first, where images downloaded through the browser extension will be stored.',
-                );
-              }
-        }
-        label="Browser extension support"
-      />
+      <fieldset>
+        <legend>Browser extension support</legend>
+        <Toggle
+          checked={isClipEnabled}
+          onChange={
+            isClipEnabled || importDirectory
+              ? toggleClipServer
+              : (e) => {
+                  console.log('came here');
+                  e.preventDefault();
+                  e.stopPropagation();
+                  alert(
+                    'Please choose a download directory first, where images downloaded through the browser extension will be stored.',
+                  );
+                }
+          }
+        />
+      </fieldset>
 
       <fieldset>
         <legend>Browser extension download directory (must be in a Location)</legend>
@@ -520,9 +533,3 @@ const toggleFullScreen = (e: React.FormEvent<HTMLInputElement>) => {
   localStorage.setItem(WINDOW_STORAGE_KEY, JSON.stringify({ isFullScreen }));
   RendererMessenger.setFullScreen(isFullScreen);
 };
-
-const toggleClipServer = (event: React.ChangeEvent<HTMLInputElement>) =>
-  RendererMessenger.setClipServerEnabled({ isClipServerRunning: event.target.checked });
-
-const toggleRunInBackground = (event: React.ChangeEvent<HTMLInputElement>) =>
-  RendererMessenger.setRunInBackground({ isRunInBackground: event.target.checked });

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -179,9 +179,9 @@ const ImportExport = observer(() => {
       <h3>File Metadata</h3>
 
       <Callout icon={IconSet.INFO}>
-        This option is useful for importing/exporting tags from/to other software, or when you use
-        Allusion on multiple devices and want to synchronize the data using a service such as
-        Dropbox or Google Drive.
+        This option is useful for importing/exporting tags from/to other software. If you use a
+        service like Dropbox or Google, you can write your tags to your files on one device and read
+        them on other devices.
       </Callout>
       <label id="hierarchical-separator">
         <span>
@@ -215,8 +215,8 @@ const ImportExport = observer(() => {
         />
         <Alert
           open={isConfirmingMetadataExport}
-          title="Are you sure you want to write Allusion's tags to your image files?"
-          information="This will overwrite any existing tags ('keywords') on those files, so it is recommended you have imported them first"
+          title="Are you sure you want to overwrite your files' tags?"
+          information="This will overwrite any existing tags ('keywords') in those files with Allusion's tags. It is recommended to import all tags before writing new tags."
           primaryButtonText="Export"
           closeButtonText="Cancel"
           onClick={(button) => {

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -92,7 +92,7 @@ class FileStore {
             );
             if (match) {
               // If there is a match to the leaf tag, just add it to the file
-              this.fileList[i].addTag(match);
+              runInAction(() => this.fileList[i].addTag(match));
             } else {
               // If there is no direct match to the leaf, insert it in the tag hierarchy: first check if any of its parents exist
               let curTag = tagStore.root;

--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -76,7 +76,7 @@ class LocationStore {
           },
           'retry-init',
         );
-      }, 5000);
+      }, 10000);
 
       console.debug('Location init...');
       const filePaths = await location.init();

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -31,7 +31,7 @@ class RootStore {
   readonly uiStore: UiStore;
   readonly clearDatabase: () => Promise<void>;
 
-  constructor(backend: Backend) {
+  constructor(private backend: Backend) {
     this.tagStore = new TagStore(backend, this);
     this.fileStore = new FileStore(backend, this);
     this.locationStore = new LocationStore(backend, this);
@@ -65,6 +65,18 @@ class RootStore {
 
     // Upon loading data, initialize UI state.
     this.uiStore.init();
+  }
+
+  async backupDatabaseToFile(path: string) {
+    return this.backend.backupDatabaseToFile(path);
+  }
+
+  async restoreDatabaseFromFile(path: string) {
+    return this.backend.restoreDatabaseFromFile(path);
+  }
+
+  async peekDatabaseFile(path: string) {
+    return this.backend.peekDatabaseFile(path);
   }
 }
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -1,12 +1,12 @@
-import { comboMatches, getKeyCombo, parseKeyCombo } from '../hotkeyParser';
 import fse from 'fs-extra';
 import { action, computed, makeObservable, observable, observe } from 'mobx';
-import path from 'path';
+import { getDefaultThumbnailDirectory } from 'src/config';
 import { ClientFile, IFile } from 'src/entities/File';
 import { ID } from 'src/entities/ID';
 import { ClientBaseCriteria, ClientTagSearchCriteria } from 'src/entities/SearchCriteria';
 import { ClientTag, ROOT_TAG_ID } from 'src/entities/Tag';
 import { RendererMessenger } from 'src/Messaging';
+import { comboMatches, getKeyCombo, parseKeyCombo } from '../hotkeyParser';
 import { clamp, debounce } from '../utils';
 import RootStore from './RootStore';
 
@@ -733,16 +733,11 @@ class UiStore {
 
     // Set default thumbnail directory in case none was specified
     if (this.thumbnailDirectory.length === 0) {
-      UiStore.getDefaultThumbnailDirectory().then((defaultThumbDir) => {
+      getDefaultThumbnailDirectory().then((defaultThumbDir) => {
         this.setThumbnailDirectory(defaultThumbDir);
         fse.ensureDirSync(this.thumbnailDirectory);
       });
     }
-  }
-
-  static async getDefaultThumbnailDirectory() {
-    const userDataPath = await RendererMessenger.getPath('temp');
-    return path.join(userDataPath, 'Allusion', 'thumbnails');
   }
 
   @action storePersistentPreferences() {

--- a/src/frontend/utils.ts
+++ b/src/frontend/utils.ts
@@ -235,7 +235,6 @@ export const ellipsize = (
 //// Date/time utils ////
 /////////////////////////
 const DateTimeFormat = new Intl.DateTimeFormat(undefined, {
-  timeZone: 'UTC',
   year: 'numeric',
   month: '2-digit',
   day: '2-digit',
@@ -254,6 +253,11 @@ export const jsDateFormatter = {
   parseDate: (str: string) => new Date(str),
   placeholder: 'Choose a date...',
 };
+
+/** Returns date in YYYYMMDDTHHMMSS format (ISO-string without symbols and milliseconds) */
+export function getFilenameFriendlyFormattedDateTime(date: Date) {
+  return date.toISOString().replaceAll(/-|:/g, '').slice(0, -5);
+}
 
 //////////////////////
 //// Color utils /////

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -42,11 +42,13 @@ export class FolderWatcherWorker {
         // - chokidar also matches entire directories: if those contain a dot, it will be ignored too, since they don't end with an image extension
         // So now we use a callback function that also provides `stats` through which we can detect whether the path is a file or a directory
 
+        const basename = SysPath.basename(path);
         const ext = SysPath.extname(path).toLowerCase().split('.')[1];
 
         // If the path doesn't have an extension: it's likely a directory: don't ignore
+        // but if it's a .dot directory, it should be ignored: will be checked later
         // In the unlikely situation it's a file, we'll filter it out later in the .on('add', ...)
-        if (!ext) return false;
+        if (!ext && !basename.startsWith('.')) return false;
         // If the path (file or directory) ends with an image extension: don't ignore it
         if (IMG_EXTENSIONS.includes(ext as IMG_EXTENSIONS_TYPE)) return false;
 

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -1,8 +1,9 @@
 import chokidar, { FSWatcher } from 'chokidar';
 import { expose } from 'comlink';
+import { Stats } from 'fs';
 import SysPath from 'path';
 import { RECURSIVE_DIR_WATCH_DEPTH } from 'src/config';
-import { IMG_EXTENSIONS } from 'src/entities/File';
+import { IMG_EXTENSIONS, IMG_EXTENSIONS_TYPE } from 'src/entities/File';
 
 const ctx: Worker = self as any;
 
@@ -23,22 +24,43 @@ export class FolderWatcherWorker {
   /** Returns all supported image files in the given directly, and callbacks for new or removed files */
   async watch(directory: string) {
     this.isCancelled = false;
-    // Only watch for images files, something like /^.*\.(?!jpg$|png$)[^.]+$/i -> https://regexr.com/5pvbu
-    const imageExtensionIgnorePattern = new RegExp(
-      `^.*\\.(?!${IMG_EXTENSIONS.join('$|')}$)[^.]+$`,
-      'i',
-    );
 
-    // Watch for changes
+    // Replace backslash with forward slash, recommendeded by chokidar
+    // See docs for the .watch method: https://github.com/paulmillr/chokidar#api
+    directory = directory.replace(/\\/g, '/');
+
+    // Watch for files being added/changed/removed:
+    // Usually you'd include a glob in the watch argument, e.g. `directory/**/.{jpg|png|...}`, but we cannot use globs unfortunately (see disableGlobbing)
+    // Instead, we ignore everything but image files in the `ignored` option
     this.watcher = chokidar.watch(directory, {
-      disableGlobbing: true, // needed in order to support folders with brackets, quotes, etc.
-      depth: RECURSIVE_DIR_WATCH_DEPTH,
-      ignored: [
-        // Ignore dot files. Also dot folders?
-        /(^|[\/\\])\../,
-        // And non-image files
-        imageExtensionIgnorePattern,
-      ],
+      disableGlobbing: true, // needed in order to support directories with brackets, quotes, asterisks, etc.
+      alwaysStat: true, // we need stats anyways during importing
+      depth: RECURSIVE_DIR_WATCH_DEPTH, // not really needed: added as a safety measure for infinite recursion between symbolic links
+      ignored: (path: string, stats?: Stats) => {
+        // We used to set `ignored` with regex patterns, but ran into problem with directories that include dots:
+        // - we ignore everything but image files, but:
+        // - chokidar also matches entire directories: if those contain a dot, it will be ignored too, since they don't end with an image extension
+        // So now we use a callback function that also provides `stats` through which we can detect whether the path is a file or a directory
+
+        const ext = SysPath.extname(path).toLowerCase();
+        // If the path doesn't have an extension: it's likely a directory: don't ignore
+        // In the unlikely situation it's a file, we'll filter it out later in the .on('add', ...)
+        if (!ext) return false;
+        // If the path (file or directory) ends with an image extension: don't ignore it
+        if (IMG_EXTENSIONS.includes(ext as IMG_EXTENSIONS_TYPE)) return false;
+
+        // Otherwise, we need to know whether it is a file or a directory before making a decision
+        // If we don't return anything, this callback will be called a second time, with the stats variable as second argument
+        if (stats) {
+          if (stats.isDirectory()) {
+            // Ignore dot directories like `/home/.hidden-directory/` but not `/home/directory.with.dots/`
+            if (SysPath.basename(path).startsWith('.')) return true;
+          } else {
+            // Not a directory, and not an image file either. Ignore!
+            return true;
+          }
+        }
+      },
     });
 
     const watcher = this.watcher;
@@ -48,13 +70,15 @@ export class FolderWatcherWorker {
 
     return new Promise<string[]>((resolve) => {
       watcher
-        .on('add', async (path: string) => {
+        .on('add', async (path) => {
+          // TODO: We already get file stats here as second arg, no need to get those later for importing in DB
           if (this.isCancelled) {
             console.log('Cancelling file watching');
             await watcher.close();
             this.isCancelled = false;
           }
-          if (IMG_EXTENSIONS.some((ext) => SysPath.extname(path).toLowerCase().endsWith(ext))) {
+          const ext = SysPath.extname(path).toLowerCase() as IMG_EXTENSIONS_TYPE;
+          if (IMG_EXTENSIONS.includes(ext)) {
             if (this.isReady) {
               ctx.postMessage({ type: 'add', value: path });
             } else {
@@ -63,10 +87,16 @@ export class FolderWatcherWorker {
           }
         })
         // .on('change', (path: string) => console.debug(`File ${path} has been changed`))
+        // TODO: on directory change: update location hierarchy list
         .on('unlink', (path: string) => ctx.postMessage({ type: 'remove', value: path }))
         .on('ready', () => {
           this.isReady = true;
           resolve(initialFiles);
+
+          // TODO: Clear memory: initialFiles no longer needed
+          // Update: tried it, didn't work as expected: list was emptied before sent back to main thread
+          // maybe send a message from main thread after initialization is finished instead?
+          // initialFiles.splice(0, initialFiles.length);
         })
         .on('error', (error) => {
           console.error('Error fired in watcher', directory, error);

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -42,13 +42,15 @@ export class FolderWatcherWorker {
         // - chokidar also matches entire directories: if those contain a dot, it will be ignored too, since they don't end with an image extension
         // So now we use a callback function that also provides `stats` through which we can detect whether the path is a file or a directory
 
-        const basename = SysPath.basename(path);
         const ext = SysPath.extname(path).toLowerCase().split('.')[1];
+        const basename = SysPath.basename(path);
+
+        // Ignore .dot files and folders
+        if (basename.startsWith('.')) return true;
 
         // If the path doesn't have an extension: it's likely a directory: don't ignore
-        // but if it's a .dot directory, it should be ignored: will be checked later
-        // In the unlikely situation it's a file, we'll filter it out later in the .on('add', ...)
-        if (!ext && !basename.startsWith('.')) return false;
+        // In the unlikely situation it is a file, we'll filter it out later in the .on('add', ...)
+        if (!ext) return false;
         // If the path (file or directory) ends with an image extension: don't ignore it
         if (IMG_EXTENSIONS.includes(ext as IMG_EXTENSIONS_TYPE)) return false;
 

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -42,7 +42,8 @@ export class FolderWatcherWorker {
         // - chokidar also matches entire directories: if those contain a dot, it will be ignored too, since they don't end with an image extension
         // So now we use a callback function that also provides `stats` through which we can detect whether the path is a file or a directory
 
-        const ext = SysPath.extname(path).toLowerCase();
+        const ext = SysPath.extname(path).toLowerCase().split('.')[1];
+
         // If the path doesn't have an extension: it's likely a directory: don't ignore
         // In the unlikely situation it's a file, we'll filter it out later in the .on('add', ...)
         if (!ext) return false;
@@ -55,6 +56,7 @@ export class FolderWatcherWorker {
           if (stats.isDirectory()) {
             // Ignore dot directories like `/home/.hidden-directory/` but not `/home/directory.with.dots/`
             if (SysPath.basename(path).startsWith('.')) return true;
+            return false;
           } else {
             // Not a directory, and not an image file either. Ignore!
             return true;
@@ -77,8 +79,9 @@ export class FolderWatcherWorker {
             await watcher.close();
             this.isCancelled = false;
           }
-          const ext = SysPath.extname(path).toLowerCase() as IMG_EXTENSIONS_TYPE;
-          if (IMG_EXTENSIONS.includes(ext)) {
+
+          const ext = SysPath.extname(path).toLowerCase().split('.')[1];
+          if (IMG_EXTENSIONS.includes(ext as IMG_EXTENSIONS_TYPE)) {
             if (this.isReady) {
               ctx.postMessage({ type: 'add', value: path });
             } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,88 +21,10 @@ import { isDev } from './config';
 import { ITag, ROOT_TAG_ID } from './entities/Tag';
 import { MainMessenger, WindowSystemButtonPress } from './Messaging';
 
-let mainWindow: BrowserWindow | null;
-let previewWindow: BrowserWindow | null;
-let tray: Tray | null;
-let clipServer: ClipServer | null;
-
-const windowStateFilePath = path.join(app.getPath('userData'), 'windowState.json');
-
-const isMac = process.platform === 'darwin';
-
-const relaunchNow = () => {
-  app.relaunch();
-  app.exit();
-};
-
-/** Returns whether main window is open - so whether files can be immediately imported */
-const importExternalImage = async (item: IImportItem) => {
-  if (mainWindow) {
-    MainMessenger.sendImportExternalImage(mainWindow.webContents, { item });
-    return true;
-  }
-  return false;
-};
-
-const addTagsToFile = async (item: IImportItem) => {
-  if (mainWindow) {
-    MainMessenger.sendAddTagsToFile(mainWindow.webContents, { item });
-    return true;
-  }
-  return false;
-};
-
-const getTags = async (): Promise<ITag[]> => {
-  if (mainWindow) {
-    const { tags } = await MainMessenger.getTags(mainWindow.webContents);
-    return tags.filter((t) => t.id !== ROOT_TAG_ID);
-  }
-  return [];
-};
-
-// Based on https://github.com/electron/electron/issues/526
-const getPreviousWindowState = (): BrowserWindowConstructorOptions & { isMaximized?: boolean } => {
-  const options: BrowserWindowConstructorOptions & { isMaximized?: boolean } = {};
-  try {
-    if (fse.existsSync(windowStateFilePath)) {
-      const state = fse.readJSONSync(windowStateFilePath);
-      if (state) {
-        const area = screen.getDisplayMatching(state).workArea;
-        // If the saved position still valid (the window is entirely inside the display area), use it.
-        if (
-          state.x >= area.x &&
-          state.y >= area.y &&
-          state.x + state.width <= area.x + area.width &&
-          state.y + state.height <= area.y + area.height
-        ) {
-          options.x = state.x;
-          options.y = state.y;
-        }
-        // If the saved size is still valid, use it.
-        if (state.width <= area.width || state.height <= area.height) {
-          options.width = state.width;
-          options.height = state.height;
-        }
-        options.isMaximized = state.isMaximized;
-      }
-    }
-  } catch (e) {
-    console.error('Could not read bounds file!', e);
-  }
-  return options;
-};
-
-// Save window position and bounds: https://github.com/electron/electron/issues/526
-let saveBoundsTimeout: ReturnType<typeof setTimeout> | null = null;
-function saveWindowStateSoon() {
-  if (saveBoundsTimeout) clearTimeout(saveBoundsTimeout);
-  saveBoundsTimeout = setTimeout(() => {
-    saveBoundsTimeout = null;
-    const state: any = mainWindow?.getNormalBounds();
-    state.isMaximized = mainWindow?.isMaximized();
-    fse.writeFileSync(windowStateFilePath, JSON.stringify(state, null, 2));
-  }, 1000);
-}
+let mainWindow: BrowserWindow | null = null;
+let previewWindow: BrowserWindow | null = null;
+let tray: Tray | null = null;
+let clipServer: ClipServer | null = null;
 
 let initialize = () => {
   console.error('Placeholder function. App was not properly initialized!');
@@ -110,10 +32,10 @@ let initialize = () => {
 
 function createTrayMenu() {
   const onTrayClick = () =>
-    !mainWindow || mainWindow.isDestroyed() ? initialize() : mainWindow.focus();
+    mainWindow === null || mainWindow.isDestroyed() ? initialize() : mainWindow.focus();
 
-  if (!tray || tray.isDestroyed()) {
-    tray = new Tray(`${__dirname}/${isMac ? TrayIconMac : TrayIcon}`);
+  if (tray === null || tray.isDestroyed()) {
+    tray = new Tray(`${__dirname}/${IS_MAC ? TrayIconMac : TrayIcon}`);
     const trayMenu = Menu.buildFromTemplate([
       {
         label: 'Open',
@@ -131,16 +53,7 @@ function createTrayMenu() {
   }
 }
 
-const clamp = (value: number, min: number, max: number): number =>
-  Math.max(min, Math.min(value, max));
-
-const setZoomFactorClamped = (win: BrowserWindow | null, factor: number) => {
-  win?.webContents.setZoomFactor(clamp(factor, 0.5, 2));
-};
-
 function createWindow() {
-  const { width, height } = screen.getPrimaryDisplay().workAreaSize;
-
   // Remember window size and position
   const previousWindowState = getPreviousWindowState();
 
@@ -155,10 +68,8 @@ function createWindow() {
       nativeWindowOpen: true,
       nodeIntegrationInSubFrames: true,
     },
-    width,
-    height,
-    minWidth: 240,
-    minHeight: 64,
+    minWidth: MIN_WINDOW_WIDTH,
+    minHeight: MIN_WINDOW_HEIGHT,
     icon: `${__dirname}/${AppIcon}`,
     // Should be same as body background: Only for split second before css is loaded
     backgroundColor: '#1c1e23',
@@ -178,13 +89,14 @@ function createWindow() {
       return;
     }
 
-    const windowTitles: { [key: string]: string } = {
+    const WINDOW_TITLES: { [key: string]: string } = {
       settings: 'Settings',
       'help-center': 'Help Center',
       about: 'About',
     };
-    if (!(frameName in windowTitles)) return;
-
+    if (!(frameName in WINDOW_TITLES)) {
+      return;
+    }
     // Note: For pop-out windows, the native frame is enabled
     // but it appears to not work on OSX, likely due to setting the parent window
 
@@ -194,7 +106,7 @@ function createWindow() {
       parent: mainWindow,
       width: 680,
       height: 480,
-      title: `${windowTitles[frameName]} • Allusion`,
+      title: `${WINDOW_TITLES[frameName]} • Allusion`,
       frame: true,
       titleBarStyle: 'default',
     };
@@ -215,20 +127,22 @@ function createWindow() {
     });
   });
 
-  mainWindow.addListener(
-    'enter-full-screen',
-    () => mainWindow && MainMessenger.fullscreenChanged(mainWindow.webContents, true),
-  );
+  mainWindow.addListener('enter-full-screen', () => {
+    if (mainWindow !== null) {
+      MainMessenger.fullscreenChanged(mainWindow.webContents, true);
+    }
+  });
 
-  mainWindow.addListener(
-    'leave-full-screen',
-    () => mainWindow && MainMessenger.fullscreenChanged(mainWindow.webContents, false),
-  );
+  mainWindow.addListener('leave-full-screen', () => {
+    if (mainWindow !== null) {
+      MainMessenger.fullscreenChanged(mainWindow.webContents, false);
+    }
+  });
 
-  mainWindow.addListener('resize', saveWindowStateSoon);
-  mainWindow.addListener('move', saveWindowStateSoon);
-  mainWindow.addListener('unmaximize', saveWindowStateSoon);
-  mainWindow.addListener('maximize', saveWindowStateSoon);
+  mainWindow.addListener('resize', saveWindowState);
+  mainWindow.addListener('move', saveWindowState);
+  mainWindow.addListener('unmaximize', saveWindowState);
+  mainWindow.addListener('maximize', saveWindowState);
 
   let menu = null;
 
@@ -266,12 +180,12 @@ function createWindow() {
     label: 'View',
     submenu: [
       {
-        // Alternative to reload: Just reloading window seems to cause a crash (started happening since the recent WASM changes)
-        // A restart of the whole electron app circumvents that.
-        // but not always
+        // FIXME: Just reloading window crashes due to an Electron bug related
+        // to WASM.
+        // A restart of the whole electron app circumvents that but not always.
         label: 'Reload',
         accelerator: 'CommandOrControl+R',
-        click: relaunchNow,
+        click: forceRelaunch,
       },
       { role: 'toggleDevTools' },
       { type: 'separator' },
@@ -289,8 +203,10 @@ function createWindow() {
         // TODO: Fix by using custom solution...
         accelerator: 'CommandOrControl+=',
         click: (_, browserWindow) => {
-          if (browserWindow) {
-            setZoomFactorClamped(browserWindow, browserWindow.webContents.zoomFactor + 0.1);
+          if (browserWindow !== undefined) {
+            browserWindow.webContents.setZoomFactor(
+              Math.min(browserWindow.webContents.zoomFactor + 0.1, MAX_ZOOM_FACTOR),
+            );
           }
         },
       },
@@ -298,8 +214,10 @@ function createWindow() {
         label: 'Zoom Out',
         accelerator: 'CommandOrControl+-',
         click: (_, browserWindow) => {
-          if (browserWindow) {
-            setZoomFactorClamped(browserWindow, browserWindow.webContents.zoomFactor - 0.1);
+          if (browserWindow !== undefined) {
+            browserWindow.webContents.setZoomFactor(
+              Math.max(browserWindow.webContents.zoomFactor - 0.1, MIN_ZOOM_FACTOR),
+            );
           }
         },
       },
@@ -331,7 +249,7 @@ function createWindow() {
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
     mainWindow = null;
-    if (previewWindow && !previewWindow.isDestroyed()) {
+    if (previewWindow !== null && !previewWindow.isDestroyed()) {
       previewWindow.close();
     }
   });
@@ -348,13 +266,13 @@ function createWindow() {
     }
   });
 
-  if (!clipServer) {
+  if (clipServer === null) {
     clipServer = new ClipServer(importExternalImage, addTagsToFile, getTags);
   }
 
   // System tray icon: Always show on Mac, or other platforms when the app is running in the background
   // Useful for browser extension, so it will work even when the window is closed
-  if (isMac || clipServer.isRunInBackgroundEnabled()) {
+  if (IS_MAC || clipServer.isRunInBackgroundEnabled()) {
     createTrayMenu();
   }
 
@@ -372,7 +290,7 @@ function createWindow() {
 function createPreviewWindow() {
   // Get display where main window is located
   let display = screen.getPrimaryDisplay();
-  if (mainWindow) {
+  if (mainWindow !== null) {
     const winBounds = mainWindow.getBounds();
     display = screen.getDisplayNearestPoint({ x: winBounds.x, y: winBounds.y });
   }
@@ -396,12 +314,12 @@ function createPreviewWindow() {
   previewWindow.loadURL(`file://${__dirname}/index.html?preview=true`);
   previewWindow.on('close', (e) => {
     // Prevent close, hide the window instead, for faster launch next time
-    if (mainWindow) {
+    if (mainWindow !== null) {
       e.preventDefault();
       MainMessenger.sendClosedPreviewWindow(mainWindow.webContents);
       mainWindow.focus();
     }
-    if (previewWindow) {
+    if (previewWindow !== null) {
       previewWindow.hide();
     }
   });
@@ -415,7 +333,7 @@ initialize = () => {
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
-  if (!(clipServer && clipServer.isRunInBackgroundEnabled())) {
+  if (clipServer === null || clipServer.isRunInBackgroundEnabled()) {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform !== 'darwin') {
@@ -434,8 +352,8 @@ app.on('activate', () => {
 
 // Ensure only a single instance of Allusion can be open
 // https://www.electronjs.org/docs/api/app#apprequestsingleinstancelock
-const gotTheLock = app.requestSingleInstanceLock();
-if (!gotTheLock) {
+const HAS_INSTANCE_LOCK = app.requestSingleInstanceLock();
+if (!HAS_INSTANCE_LOCK) {
   console.log('Another instance of Allusion is already running');
   app.quit();
 } else {
@@ -473,7 +391,9 @@ autoUpdater.on('error', (error) => {
 });
 
 autoUpdater.on('update-available', async (info: UpdateInfo) => {
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow === null || mainWindow.isDestroyed()) {
+    return;
+  }
 
   const message = `Update available: ${info.releaseName || info.version}:\nDo you want update now?`;
   // info.releaseNotes attribute is HTML, could show that in renderer at some point
@@ -499,7 +419,9 @@ autoUpdater.on('update-not-available', () => {
     return;
   }
   // Could also show this as a toast!
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (mainWindow === null || mainWindow.isDestroyed()) {
+    return;
+  }
   dialog.showMessageBox(mainWindow, {
     title: 'No Update Available',
     message: `Current version is up-to-date (v${getVersion()})!`,
@@ -548,7 +470,7 @@ MainMessenger.onStoreFile(({ directory, filenameWithExt, imgBase64 }) =>
 // Forward files from the main window to the preview window
 MainMessenger.onSendPreviewFiles((msg) => {
   // Create preview window if needed, and send the files selected in the primary window
-  if (!previewWindow || previewWindow.isDestroyed()) {
+  if (previewWindow === null || previewWindow.isDestroyed()) {
     // The Window object might've been destroyed if it was hidden for too long -> Recreate it
     if (previewWindow?.isDestroyed()) {
       console.warn('Preview window was destroyed! Attemping to recreate...');
@@ -578,7 +500,8 @@ MainMessenger.onDragExport((absolutePaths) => {
   }
 
   let previewIcon = nativeImage.createFromPath(absolutePaths[0]);
-  if (previewIcon) {
+  const isPreviewEmpty = previewIcon.isEmpty();
+  if (!isPreviewEmpty) {
     // Resize preview to something resonable: taking into account aspect ratio
     const ratio = previewIcon.getAspectRatio();
     previewIcon =
@@ -591,15 +514,15 @@ MainMessenger.onDragExport((absolutePaths) => {
     files: absolutePaths,
     // Just show the first image as a thumbnail for now
     // TODO: Show some indication that multiple images are dragged, would be cool to show a stack of the first few of them
-    icon: previewIcon.isEmpty() ? AppIcon : previewIcon,
+    icon: isPreviewEmpty ? AppIcon : previewIcon,
   } as any);
 });
 
-MainMessenger.onClearDatabase(relaunchNow);
+MainMessenger.onClearDatabase(forceRelaunch);
 
 MainMessenger.onToggleDevTools(() => mainWindow?.webContents.toggleDevTools());
 
-MainMessenger.onReload(relaunchNow);
+MainMessenger.onReload(forceRelaunch);
 
 MainMessenger.onOpenDialog(dialog);
 
@@ -611,7 +534,12 @@ MainMessenger.onSetFullScreen((isFullScreen) => mainWindow?.setFullScreen(isFull
 
 MainMessenger.onGetZoomFactor(() => mainWindow?.webContents.zoomFactor ?? 1);
 
-MainMessenger.onSetZoomFactor((factor: number) => setZoomFactorClamped(mainWindow, factor));
+MainMessenger.onSetZoomFactor((factor) => {
+  if (mainWindow !== null) {
+    const zoom = Math.max(MIN_ZOOM_FACTOR, Math.min(factor, MAX_ZOOM_FACTOR));
+    mainWindow.webContents.setZoomFactor(zoom);
+  }
+});
 
 MainMessenger.onWindowSystemButtonPressed((button: WindowSystemButtonPress) => {
   if (mainWindow !== null) {
@@ -640,7 +568,85 @@ MainMessenger.onWindowSystemButtonPressed((button: WindowSystemButtonPress) => {
 
 MainMessenger.onIsMaximized(() => mainWindow?.isMaximized() ?? false);
 
-function getVersion() {
+MainMessenger.onGetVersion(getVersion);
+
+MainMessenger.onCheckForUpdates(() => autoUpdater.checkForUpdates());
+
+// Helper functions and variables/constants
+
+const IS_MAC = process.platform === 'darwin';
+const MIN_ZOOM_FACTOR = 0.5;
+const MAX_ZOOM_FACTOR = 2;
+const MIN_WINDOW_WIDTH = 240;
+const MIN_WINDOW_HEIGHT = 64;
+
+const windowStateFilePath = path.join(app.getPath('userData'), 'windowState.json');
+
+// Based on https://github.com/electron/electron/issues/526
+function getPreviousWindowState(): Electron.Rectangle & { isMaximized?: boolean } {
+  const options: Electron.Rectangle & { isMaximized?: boolean } = {
+    x: 0,
+    y: 0,
+    width: MIN_WINDOW_WIDTH,
+    height: MIN_WINDOW_HEIGHT,
+  };
+  try {
+    const state = fse.readJSONSync(windowStateFilePath);
+    state.x = Number(state.x);
+    state.y = Number(state.y);
+    state.width = Number(state.width);
+    state.height = Number(state.height);
+    state.isMaximized = Boolean(state.isMaximized);
+
+    const area = screen.getDisplayMatching(state).workArea;
+    // If the saved position still valid (the window is entirely inside the display area), use it.
+    if (
+      state.x >= area.x &&
+      state.y >= area.y &&
+      state.x + state.width <= area.x + area.width &&
+      state.y + state.height <= area.y + area.height
+    ) {
+      options.x = state.x;
+      options.y = state.y;
+    }
+    // If the saved size is still valid, use it.
+    if (state.width <= area.width || state.height <= area.height) {
+      options.width = state.width;
+      options.height = state.height;
+    }
+    options.isMaximized = state.isMaximized;
+  } catch (e) {
+    console.error('Could not read window state file!', e);
+    // Fallback to primary display screen size
+    const { width, height } = screen.getPrimaryDisplay().workAreaSize;
+    options.width = width;
+    options.height = height;
+  }
+  return options;
+}
+
+// Save window position and bounds: https://github.com/electron/electron/issues/526
+let saveBoundsTimeout: ReturnType<typeof setTimeout> | null = null;
+function saveWindowState() {
+  if (saveBoundsTimeout) clearTimeout(saveBoundsTimeout);
+  saveBoundsTimeout = setTimeout(() => {
+    saveBoundsTimeout = null;
+    if (mainWindow !== null) {
+      const state = Object.assign(
+        { isMaximized: mainWindow.isMaximized() },
+        mainWindow.getNormalBounds(),
+      );
+      fse.writeFileSync(windowStateFilePath, JSON.stringify(state, null, 2));
+    }
+  }, 1000);
+}
+
+function forceRelaunch() {
+  app.relaunch();
+  app.exit();
+}
+
+function getVersion(): string {
   if (isDev()) {
     // Weird quirk: it returns the Electron version in dev mode
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -649,6 +655,28 @@ function getVersion() {
     return app.getVersion();
   }
 }
-MainMessenger.onGetVersion(() => getVersion());
 
-MainMessenger.onCheckForUpdates(() => autoUpdater.checkForUpdates());
+/** Returns whether main window is open - so whether files can be immediately imported */
+async function importExternalImage(item: IImportItem): Promise<boolean> {
+  if (mainWindow !== null) {
+    MainMessenger.sendImportExternalImage(mainWindow.webContents, { item });
+    return true;
+  }
+  return false;
+}
+
+async function addTagsToFile(item: IImportItem): Promise<boolean> {
+  if (mainWindow !== null) {
+    MainMessenger.sendAddTagsToFile(mainWindow.webContents, { item });
+    return true;
+  }
+  return false;
+}
+
+async function getTags(): Promise<ITag[]> {
+  if (mainWindow !== null) {
+    const { tags } = await MainMessenger.getTags(mainWindow.webContents);
+    return tags.filter((t) => t.id !== ROOT_TAG_ID);
+  }
+  return [];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ function initialize() {
 }
 
 function getMainWindowDisplay() {
-  if (mainWindow) {
+  if (mainWindow !== null) {
     const winBounds = mainWindow.getBounds();
     return screen.getDisplayNearestPoint({
       x: winBounds.x + winBounds.width / 2,

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,13 @@ function createTrayMenu() {
   }
 }
 
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max));
+
+const setZoomFactorClamped = (win: BrowserWindow | null, factor: number) => {
+  win?.webContents.setZoomFactor(clamp(factor, 0.5, 2));
+};
+
 function createWindow() {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
 
@@ -284,7 +291,7 @@ function createWindow() {
         accelerator: 'CommandOrControl+=',
         click: (_, browserWindow) => {
           if (browserWindow) {
-            browserWindow.webContents.zoomFactor += 0.1;
+            setZoomFactorClamped(browserWindow, browserWindow.webContents.zoomFactor + 0.1);
           }
         },
       },
@@ -293,7 +300,7 @@ function createWindow() {
         accelerator: 'CommandOrControl+-',
         click: (_, browserWindow) => {
           if (browserWindow) {
-            browserWindow.webContents.zoomFactor -= 0.1;
+            setZoomFactorClamped(browserWindow, browserWindow.webContents.zoomFactor - 0.1);
           }
         },
       },
@@ -591,7 +598,7 @@ MainMessenger.onSetFullScreen((isFullScreen) => mainWindow?.setFullScreen(isFull
 
 MainMessenger.onGetZoomFactor(() => mainWindow?.webContents.zoomFactor ?? 1);
 
-MainMessenger.onSetZoomFactor((level: number) => mainWindow?.webContents.setZoomFactor(level));
+MainMessenger.onSetZoomFactor((factor: number) => setZoomFactorClamped(mainWindow, factor));
 
 MainMessenger.onWindowSystemButtonPressed((button: WindowSystemButtonPress) => {
   if (mainWindow !== null) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,17 +32,6 @@ function initialize() {
   createPreviewWindow();
 }
 
-function getMainWindowDisplay() {
-  if (mainWindow !== null) {
-    const winBounds = mainWindow.getBounds();
-    return screen.getDisplayNearestPoint({
-      x: winBounds.x + winBounds.width / 2,
-      y: winBounds.y + winBounds.height / 2,
-    });
-  }
-  return screen.getPrimaryDisplay();
-}
-
 function createWindow() {
   // Remember window size and position
   const previousWindowState = getPreviousWindowState();
@@ -286,10 +275,10 @@ function createPreviewWindow() {
 
   // preview window is is sized relative to screen resolution by default
   const bounds: Rectangle = {
-    width: (display.size.height * 3) / 4,
-    height: (display.size.width * 3) / 4,
-    x: display.bounds.x + display.bounds.width / 4,
-    y: display.bounds.y + display.bounds.height / 4,
+    width: (display.size.width * 3) / 4,
+    height: (display.size.height * 3) / 4,
+    x: display.bounds.x + display.bounds.width / 8,
+    y: display.bounds.y + display.bounds.height / 8,
   };
 
   previewWindow = new BrowserWindow({
@@ -598,6 +587,17 @@ const MIN_ZOOM_FACTOR = 0.5;
 const MAX_ZOOM_FACTOR = 2;
 const MIN_WINDOW_WIDTH = 240;
 const MIN_WINDOW_HEIGHT = 64;
+
+function getMainWindowDisplay() {
+  if (mainWindow !== null) {
+    const winBounds = mainWindow.getBounds();
+    return screen.getDisplayNearestPoint({
+      x: winBounds.x + winBounds.width / 2,
+      y: winBounds.y + winBounds.height / 2,
+    });
+  }
+  return screen.getPrimaryDisplay();
+}
 
 const windowStateFilePath = path.join(app.getPath('userData'), 'windowState.json');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -347,7 +347,10 @@ if (!HAS_INSTANCE_LOCK) {
 } else {
   app.on('second-instance', () => {
     // Someone tried to run a second instance, we should focus our window.
-    if (mainWindow !== null) {
+    if (mainWindow === null || mainWindow.isDestroyed()) {
+      // In case there is no main window (could be running in background): re-initialize
+      initialize();
+    } else {
       if (mainWindow.isMinimized()) {
         mainWindow.restore();
       }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -33,7 +33,7 @@ export const IS_PREVIEW_WINDOW = params.get('preview') === 'true';
 const backend = new Backend();
 const rootStore = new RootStore(backend);
 backend
-  .init()
+  .init(!IS_PREVIEW_WINDOW)
   .then(async () => {
     console.log('Backend has been initialized!');
     await rootStore.init(IS_PREVIEW_WINDOW);

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -19,7 +19,7 @@ import RootStore from './frontend/stores/RootStore';
 
 import App from './frontend/App';
 import PreviewApp from './frontend/Preview';
-import { IS_MAC, promiseRetry, throttle } from './frontend/utils';
+import { promiseRetry } from './frontend/utils';
 
 // Window State
 export const WINDOW_STORAGE_KEY = 'Allusion_Window';
@@ -111,20 +111,8 @@ if (IS_PREVIEW_WINDOW) {
 window.addEventListener('beforeunload', () => {
   // TODO: check whether this works okay with running in background process
   // And when force-closing the application. I think it might be keep running...
+  // Update: yes, it keeps running when force-closing. Not sure how to fix. Don't think it can run as child-process
   rootStore.fileStore.exifTool.close();
-});
-
-const throttledZoom = throttle(RendererMessenger.setZoomFactor, 200);
-window.addEventListener('wheel', (e) => {
-  // Zoom with ctrl + scroll (cmd for osx)
-  const performZoom = IS_MAC ? e.metaKey : e.ctrlKey;
-  if (performZoom) {
-    const zoomFactor = RendererMessenger.getZoomFactor();
-    throttledZoom(zoomFactor + (e.deltaY < 0 ? 0.1 : -0.1));
-    e.preventDefault();
-    e.stopPropagation();
-    return false;
-  }
 });
 
 // Render our react components in the div with id 'app' in the html file

--- a/src/style.scss
+++ b/src/style.scss
@@ -11,6 +11,7 @@
 @import '~resources/style/inspector.scss'; // The inspector (right toolbar)
 
 // Individual components
+@import '~resources/style/remake/about.scss';
 @import '~resources/style/help-center.scss';
 @import '~resources/style/settings.scss';
 

--- a/widgets/Button/button.scss
+++ b/widgets/Button/button.scss
@@ -1,7 +1,6 @@
 .btn-group {
   display: flex;
   align-items: center;
-  justify-content: center;
   margin: 0 -0.25rem;
 
   .btn {

--- a/widgets/Checkbox/checkbox.scss
+++ b/widgets/Checkbox/checkbox.scss
@@ -48,6 +48,8 @@ input[type='checkbox'] {
 input[type='checkbox'][data-toggle='true'] {
   min-width: 2.5rem;
   border-radius: 2.5rem;
+  margin-left: 0;
+  margin-right: 0.75rem;
 
   &::before {
     width: 0.75rem;

--- a/widgets/Checkbox/index.tsx
+++ b/widgets/Checkbox/index.tsx
@@ -1,28 +1,29 @@
 import './checkbox.scss';
 import React from 'react';
 
+interface IToggle {
+  checked?: boolean;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onLabel?: string;
+  offLabel?: string;
+}
+
+const Toggle = (props: IToggle) => {
+  const { checked, onChange, onLabel = 'On', offLabel = 'Off' } = props;
+  return (
+    <label className="toggle">
+      <input data-toggle type="checkbox" checked={checked} onChange={onChange} />
+      {checked ? onLabel : offLabel}
+    </label>
+  );
+};
+
 interface ICheckbox {
   label: string;
   checked?: boolean;
   defaultChecked?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
-
-const Toggle = (props: ICheckbox) => {
-  const { label, defaultChecked, checked, onChange } = props;
-  return (
-    <label className="toggle">
-      {label}
-      <input
-        data-toggle
-        type="checkbox"
-        defaultChecked={defaultChecked}
-        checked={checked}
-        onChange={onChange}
-      />
-    </label>
-  );
-};
 
 const Checkbox = (props: ICheckbox) => {
   const { label, defaultChecked, checked, onChange } = props;

--- a/widgets/Combobox/combobox.scss
+++ b/widgets/Combobox/combobox.scss
@@ -5,7 +5,7 @@
   }
 
   input {
-    min-height: 1.5rem;
+    min-height: 100%;
     border: none;
     background: transparent;
   }
@@ -66,7 +66,6 @@
   border: 0.0625rem solid var(--border-color);
   outline: none;
   border-radius: 0.25rem;
-  margin: 0.125rem 0.25rem;
   cursor: text;
   line-height: 1.5rem;
 

--- a/widgets/Icons/index.tsx
+++ b/widgets/Icons/index.tsx
@@ -50,7 +50,7 @@ import FOLDER_OPEN from 'resources/icons/folder-open.svg';
 // import FOLDER_STRUCTURE from 'resources/icons/folder-structure.svg';
 // import FORM_DROP from 'resources/icons/form-drop.svg';
 import GITHUB from 'resources/icons/github.svg';
-// import IMPORT from 'resources/icons/import.svg';
+import IMPORT from 'resources/icons/import.svg';
 import HELPCENTER from 'resources/icons/helpcenter.svg';
 import INFO from 'resources/icons/info.svg';
 // import ITEM_COLLAPSE from 'resources/icons/item-collaps.svg';
@@ -146,7 +146,7 @@ const IconSet = {
   // FOLDER_STRUCTURE: toSvg(FOLDER_STRUCTURE),
   // FORM_DROP: toSvg(FORM_DROP),
   GITHUB: toSvg(GITHUB),
-  // IMPORT: toSvg(IMPORT),
+  IMPORT: toSvg(IMPORT),
   HELPCENTER: toSvg(HELPCENTER),
   INFO: toSvg(INFO),
   // ITEM_COLLAPSE: toSvg(ITEM_COLLAPSE),

--- a/widgets/Radio/radio.scss
+++ b/widgets/Radio/radio.scss
@@ -42,3 +42,13 @@ input[type='radio'] {
     border-color: var(--accent-color-blue);
   }
 }
+
+[role='radiogroup'],
+[role='radiogroup'] > div {
+  display: flex;
+  flex-direction: column;
+
+  label {
+    margin-bottom: 0.25rem;
+  }
+}

--- a/widgets/notifications/notifications.scss
+++ b/widgets/notifications/notifications.scss
@@ -1,6 +1,7 @@
 .callout {
   display: grid;
   grid-template-areas: 'icon auto' 'icon body';
+  grid-template-columns: min-content 1fr;
   border-left: 0.25rem solid var(--accent-color-blue);
   padding-left: 0.75rem;
   margin-bottom: 0.5rem;

--- a/widgets/notifications/notifications.scss
+++ b/widgets/notifications/notifications.scss
@@ -3,6 +3,7 @@
   grid-template-areas: 'icon auto' 'icon body';
   grid-template-columns: min-content 1fr;
   border-left: 0.25rem solid var(--accent-color-blue);
+  padding: 0.125rem 0;
   padding-left: 0.75rem;
   margin-bottom: 0.5rem;
   column-gap: 0.25rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5679,9 +5679,9 @@ lodash.sortby@^4.7.0:
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4645,9 +4645,9 @@ ini@2.0.0:
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 ini@^1.3.4, ini@~1.3.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
-  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 internal-slot@^1.0.2:
   version "1.0.2"
@@ -4756,9 +4756,9 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     kind-of "^6.0.2"
 
 is-docker@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -6045,9 +6045,9 @@ node-modules-regexp@^1.0.0:
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-notifier@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.0.tgz#a7eee2d51da6d0f7ff5094bc7108c911240c1620"
-  integrity sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.2.tgz#f3167a38ef0d2c8a866a83e318c1ba0efeb702c5"
+  integrity sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==
   dependencies:
     growly "^1.3.0"
     is-wsl "^2.2.0"
@@ -7273,22 +7273,17 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.3.4:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 serialize-error@^7.0.1:
   version "7.0.1"
@@ -8267,12 +8262,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
-  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
-
-uuid@^8.3.2:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,12 +2781,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
-
-colorette@^1.2.2:
+colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -5954,10 +5949,10 @@ nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
-nanoid@^3.1.22:
-  version "3.1.22"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
-  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
+nanoid@^3.1.23:
+  version "3.1.23"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
+  integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6589,12 +6584,12 @@ postcss-value-parser@^4.1.0:
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss@^8.2.8:
-  version "8.2.9"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.9.tgz#fd95ff37b5cee55c409b3fdd237296ab4096fba3"
-  integrity sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==
+  version "8.2.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.15.tgz#9e66ccf07292817d226fc315cbbf9bc148fbca65"
+  integrity sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==
   dependencies:
     colorette "^1.2.2"
-    nanoid "^3.1.22"
+    nanoid "^3.1.23"
     source-map "^0.6.1"
 
 prelude-ls@^1.2.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3198,7 +3198,14 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
-dexie@^3.0.3:
+dexie-export-import@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dexie-export-import/-/dexie-export-import-1.0.0.tgz#2e2cc375a416f540c89d2a39f623d297077221a4"
+  integrity sha512-mqtREaI+/tSEfpwOZeYNyX+FfCxTYt0RB4BIevX4wFGMQL1mQ0cWfIGXBpoRGEnHdiHbf3QNK2+0Ras3dNJfIQ==
+  dependencies:
+    dexie "^3.0.0-alpha.5 || ^2.0.4"
+
+"dexie@^3.0.0-alpha.5 || ^2.0.4", dexie@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.0.3.tgz#ede63849dfe5f07e13e99bb72a040e8ac1d29dab"
   integrity sha512-BSFhGpngnCl1DOr+8YNwBDobRMH0ziJs2vts69VilwetHYOtEDcLqo7d/XiIphM0tJZ2rPPyAGd31lgH2Ln3nw==


### PR DESCRIPTION
Fixes:
- Images in (sub)directories that contain a dot were not detected. Dot folders (e.g. `/.hidden/`) are still ignored
- Reloading Allusion crashed the application (Should fix #288 most of the time)
- The "Open external" option, for opening images in an external image viewer, did not work on Linux

Improvements:
- Tweaks to scaling the UI (closes #280)
- Child windows (Preview window, Settings, About, etc.) are now opened on the same monitor as the main window
- Some slight styling tweaks

New features:
- Added manual and automatic backups functionality (in response to #291)
- Opening a second instance of Allusion will focus the first instance instead
- Added a "Path" sorting option, which shows images in the same folder nearby
