### PR TITLE
Slide overhaul

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,8 +128,8 @@
     "react-colorful": "^5.1.1",
     "react-dom": "^16.14.0",
     "react-popper": "^2.2.5",
-    "react-responsive-pinch-zoom-pan": "^0.3.0",
     "react-window": "^1.8.6",
+    "reselect": "^4.0.0",
     "sourcemapped-stacktrace": "^1.1.11",
     "uuid": "^8.3.2"
   }

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -344,22 +344,30 @@
   left: 0;
   width: 100%;
   height: 100%;
-
-  @keyframes fade-in-bg {
-    from {background: rgba(var(--background-color), 0);}
-    to {background: var(--background-color);}
-  }
-  animation: fade-in-bg 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
-  animation-fill-mode: forwards; 
 }
 
 #zoomable-image {
   position: relative;
   min-width: 224px;
   margin: auto;
+  background: var(--background-color);
 
-  img {
-    animation: fade 0.1s cubic-bezier(0.65, 0.05, 0.36, 1);
+  @keyframes fade-in-bg {
+    from {background: rgba(var(--background-color), 0);}
+    to {background: var(--background-color);}
+  }
+  @keyframes fade-out-bg {
+    from {opacity: 1;}
+    to {opacity: 0;}
+  }
+  
+
+  &.fade-in {
+    animation: fade-in-bg 0.3s ease-in;
+  }
+  &.fade-out {
+    opacity: 0;
+    animation: fade-out-bg 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
   }
 
   [class^='side-button'] {

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -338,11 +338,25 @@
 // Slide mode:
 #slide-mode {
   flex-direction: row-reverse;
+  
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+
+  @keyframes fade-in-bg {
+    from {background: rgba(var(--background-color), 0);}
+    to {background: var(--background-color);}
+  }
+  animation: fade-in-bg 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
+  animation-fill-mode: forwards; 
 }
 
 #zoomable-image {
   position: relative;
   min-width: 224px;
+  margin: auto;
 
   img {
     animation: fade 0.1s cubic-bezier(0.65, 0.05, 0.36, 1);

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -365,6 +365,10 @@
     animation: fade-out-bg 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
   }
 }
+.preview-window-initializing #slide-mode.fade-in {
+  // Preview window initializes with slide mode: fade-in is undesired
+  animation-duration: 0s;
+}
 
 #zoomable-image {
   position: relative;

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -344,23 +344,18 @@
   left: 0;
   width: 100%;
   height: 100%;
-}
 
-#zoomable-image {
-  position: relative;
-  min-width: 224px;
-  margin: auto;
   background: var(--background-color);
 
   @keyframes fade-in-bg {
     from {background: rgba(var(--background-color), 0);}
     to {background: var(--background-color);}
   }
+
   @keyframes fade-out-bg {
     from {opacity: 1;}
     to {opacity: 0;}
   }
-  
 
   &.fade-in {
     animation: fade-in-bg 0.3s ease-in;
@@ -369,6 +364,12 @@
     opacity: 0;
     animation: fade-out-bg 0.3s cubic-bezier(0.65, 0.05, 0.36, 1);
   }
+}
+
+#zoomable-image {
+  position: relative;
+  min-width: 224px;
+  margin: auto;
 
   [class^='side-button'] {
     display: flex;

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -4,6 +4,7 @@ import { ID } from './entities/ID';
 import { ITag } from './entities/Tag';
 
 import { IImportItem } from './clipper/server';
+import { ViewMethod } from './frontend/stores/UiStore';
 
 /**
  * All types of messages between the main and renderer process in one place, with type safety.
@@ -89,6 +90,7 @@ export interface IPreviewFilesMessage {
   ids: ID[];
   activeImgId?: ID;
   thumbnailDirectory: string;
+  viewMethod: ViewMethod;
 }
 
 /////////////// Drag n drop export ///////////////

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -14,7 +14,7 @@ export const AUTO_BACKUP_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 export const dbConfig: IDBVersioningConfig[] = [
   {
     // Version 4, 19-9-20: Added system created date
-    version: 4,
+    version: 5,
     collections: [
       {
         name: 'files',

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -14,7 +14,7 @@ export const AUTO_BACKUP_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 export const dbConfig: IDBVersioningConfig[] = [
   {
     // Version 4, 19-9-20: Added system created date
-    version: 5,
+    version: 4,
     collections: [
       {
         name: 'files',

--- a/src/frontend/Preview.tsx
+++ b/src/frontend/Preview.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useCallback } from 'react';
+import React, { useContext, useEffect, useCallback, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 
 import StoreContext from './contexts/StoreContext';
@@ -29,8 +29,18 @@ const PreviewApp = observer(() => {
     [fileStore.fileList.length, uiStore],
   );
 
+  // disable fade-in on initalization (when file list changes)
+  const [isInitializing, setIsInitializing] = useState(true);
+  useEffect(() => {
+    setIsInitializing(true);
+    setTimeout(() => setIsInitializing(false), 1000);
+  }, [fileStore.fileListLastModified]);
+
   return (
-    <div id="preview" className={uiStore.theme}>
+    <div
+      id="preview"
+      className={`${uiStore.theme} ${isInitializing ? 'preview-window-initializing' : ''}`}
+    >
       <ErrorBoundary>
         <Toolbar id="toolbar" label="Preview Command Bar" controls="content-view">
           <ToolbarButton

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -317,6 +317,7 @@ const Thumbnail = observer(({ file, mounted, uiStore, forceNoThumbnail }: IThumb
         src={encodeFilePath(forceNoThumbnail ? file.absolutePath : thumbnailPath)}
         onError={handleImageError}
         alt=""
+        data-file-id={file.id}
       />
     );
   } else if (state === ThumbnailState.Loading) {

--- a/src/frontend/containers/ContentView/LayoutSwitcher.tsx
+++ b/src/frontend/containers/ContentView/LayoutSwitcher.tsx
@@ -114,25 +114,16 @@ const Layout = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileStore, handleFileSelect]);
 
-  // TODO: Keep masonry layout active while slide is open: no loading time when returning
-  if (uiStore.isSlideMode) {
-    return (
-      <SlideMode
-        contentRect={contentRect}
-        showContextMenu={showContextMenu}
-        uiStore={uiStore}
-        fileStore={fileStore}
-      />
-    );
-  }
   if (contentRect.width < 10) {
     return null;
   }
+
+  let overviewElem: React.ReactNode = undefined;
   switch (uiStore.method) {
     case ViewMethod.Grid:
     case ViewMethod.MasonryVertical:
     case ViewMethod.MasonryHorizontal:
-      return (
+      overviewElem = (
         <MasonryRenderer
           contentRect={contentRect}
           type={uiStore.method}
@@ -144,8 +135,9 @@ const Layout = ({
           handleFileSelect={handleFileSelect}
         />
       );
+      break;
     case ViewMethod.List:
-      return (
+      overviewElem = (
         <ListGallery
           contentRect={contentRect}
           select={handleFileSelect}
@@ -156,9 +148,23 @@ const Layout = ({
           handleFileSelect={handleFileSelect}
         />
       );
+      break;
     default:
-      return null;
+      overviewElem = 'unknown view method';
   }
+  return (
+    <>
+      {overviewElem}
+      {uiStore.isSlideMode && (
+        <SlideMode
+          contentRect={contentRect}
+          showContextMenu={showContextMenu}
+          uiStore={uiStore}
+          fileStore={fileStore}
+        />
+      )}
+    </>
+  );
 };
 
 export default observer(Layout);

--- a/src/frontend/containers/ContentView/LayoutSwitcher.tsx
+++ b/src/frontend/containers/ContentView/LayoutSwitcher.tsx
@@ -1,6 +1,6 @@
 import { action, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ITagDnDData } from 'src/frontend/contexts/TagDnDContext';
 import { RendererMessenger } from 'src/Messaging';
 import { ClientFile } from '../../../entities/File';
@@ -114,6 +114,19 @@ const Layout = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fileStore, handleFileSelect]);
 
+  // delay unmount of slide view so end-transition can take place.
+  // The `transitionEnd` prop is passed when slide mode is disabled,
+  // triggering the transition, then X ms later the component is unmounted
+  const { isSlideMode } = uiStore;
+  const [delayedSlideMode, setDelayedSlideMode] = useState(uiStore.isSlideMode);
+  useEffect(() => {
+    if (isSlideMode) {
+      setDelayedSlideMode(true);
+    } else {
+      setTimeout(() => setDelayedSlideMode(false), 300);
+    }
+  }, [isSlideMode]);
+
   if (contentRect.width < 10) {
     return null;
   }
@@ -152,10 +165,11 @@ const Layout = ({
     default:
       overviewElem = 'unknown view method';
   }
+
   return (
     <>
       {overviewElem}
-      {uiStore.isSlideMode && (
+      {delayedSlideMode && (
         <SlideMode
           contentRect={contentRect}
           showContextMenu={showContextMenu}

--- a/src/frontend/containers/ContentView/ListGallery.tsx
+++ b/src/frontend/containers/ContentView/ListGallery.tsx
@@ -1,6 +1,14 @@
 import { action, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import React, { useContext, useMemo, useRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  useContext,
+  useMemo,
+  useRef,
+  useCallback,
+  useEffect,
+  useState,
+  useLayoutEffect,
+} from 'react';
 import { FixedSizeList, ListOnScrollProps } from 'react-window';
 import { FileOrder } from 'src/backend/DBRepository';
 import { ClientFile } from 'src/entities/File';
@@ -54,11 +62,20 @@ const ListGallery = observer((props: ILayoutProps & IListGalleryProps) => {
 
   const index = lastSelectionIndex.current;
   const fileSelectionSize = uiStore.fileSelection.size;
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (index !== undefined && ref.current !== null && fileSelectionSize > 0) {
       ref.current.scrollToItem(Math.floor(index));
     }
   }, [index, fileSelectionSize]);
+
+  // When returning from slide mode, scroll to last shown image if not in view
+  const { isSlideMode, firstItem } = uiStore;
+  useLayoutEffect(() => {
+    if (!isSlideMode) {
+      ref.current?.scrollToItem(firstItem, 'smart');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSlideMode]);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/src/frontend/containers/ContentView/ListGallery.tsx
+++ b/src/frontend/containers/ContentView/ListGallery.tsx
@@ -51,7 +51,7 @@ const ListGallery = observer((props: ILayoutProps & IListGalleryProps) => {
   const ref = useRef<FixedSizeList>(null);
 
   const throttledScrollHandler = useRef(
-    debouncedThrottle((index: number) => uiStore.setFirstItem(index), 100),
+    debouncedThrottle((index: number) => !uiStore.isSlideMode && uiStore.setFirstItem(index), 100),
   );
 
   const handleScroll = useCallback(
@@ -68,14 +68,14 @@ const ListGallery = observer((props: ILayoutProps & IListGalleryProps) => {
     }
   }, [index, fileSelectionSize]);
 
-  // When returning from slide mode, scroll to last shown image if not in view
+  // While in slide mode, scroll to last shown image if not in view, for transition back to gallery
   const { isSlideMode, firstItem } = uiStore;
   useLayoutEffect(() => {
-    if (!isSlideMode) {
+    if (isSlideMode) {
       ref.current?.scrollToItem(firstItem, 'smart');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSlideMode]);
+  }, [isSlideMode, firstItem]);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
@@ -51,6 +51,7 @@ const VirtualizedRenderer = observer(
       [dndData, fileStore, select, showContextMenu, uiStore],
     );
     const numImages = images.length;
+    const { isSlideMode, firstItem } = uiStore;
 
     const determineRenderRegion = useCallback(
       (numImages: number, overdraw: number, setFirstItem = true) => {
@@ -90,10 +91,16 @@ const VirtualizedRenderer = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [numImages, containerWidth, containerHeight]);
 
-    const handleScroll = useCallback(() => throttledRedetermine.current(numImages, overscan || 0), [
-      numImages,
-      overscan,
-    ]);
+    const handleScroll = useCallback(
+      () =>
+        throttledRedetermine.current(
+          numImages,
+          overscan || 0,
+          // dont't scroll set first item while in slide mode due to scrolling, since it's controlled over there
+          !isSlideMode,
+        ),
+      [numImages, overscan, isSlideMode],
+    );
 
     const scrollToIndex = useCallback(
       (index: number, block: 'nearest' | 'start' | 'end' | 'center' = 'nearest') => {
@@ -137,14 +144,13 @@ const VirtualizedRenderer = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [lastSelIndex, fileSelectionSize]);
 
-    // When returning from slide mode, scroll to last shown image if not in view
-    const { isSlideMode, firstItem } = uiStore;
+    // While in slide mode, scroll to last shown image if not in view, for transition back to gallery
     useLayoutEffect(() => {
-      if (!isSlideMode) {
+      if (isSlideMode) {
         scrollToIndex(firstItem, 'nearest');
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isSlideMode]);
+    }, [isSlideMode, firstItem]);
 
     return (
       // One div as the scrollable viewport

--- a/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
@@ -141,7 +141,7 @@ const VirtualizedRenderer = observer(
     const { isSlideMode, firstItem } = uiStore;
     useLayoutEffect(() => {
       if (!isSlideMode) {
-        scrollToIndex(firstItem, 'start');
+        scrollToIndex(firstItem, 'nearest');
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isSlideMode]);

--- a/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/VirtualizedRenderer.tsx
@@ -137,6 +137,15 @@ const VirtualizedRenderer = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [lastSelIndex, fileSelectionSize]);
 
+    // When returning from slide mode, scroll to last shown image if not in view
+    const { isSlideMode, firstItem } = uiStore;
+    useLayoutEffect(() => {
+      if (!isSlideMode) {
+        scrollToIndex(firstItem, 'start');
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isSlideMode]);
+
     return (
       // One div as the scrollable viewport
       <div className={className} onScroll={handleScroll} ref={wrapperRef}>

--- a/src/frontend/containers/ContentView/SlideMode.tsx
+++ b/src/frontend/containers/ContentView/SlideMode.tsx
@@ -177,10 +177,10 @@ const SlideView = observer((props: ISlideView) => {
       transitionEnd={uiStore.isSlideMode ? undefined : transitionStart}
       prevImage={uiStore.firstItem - 1 >= 0 ? decrImgIndex : undefined}
       nextImage={uiStore.firstItem + 1 < fileStore.fileList.length ? incrImgIndex : undefined}
+      doubleClickBehavior="zoomOrReset"
       onContextMenu={handleContextMenu}
       onDrop={eventHandlers.onDrop}
       onClose={uiStore.disableSlideMode}
-      doubleClickBehavior={uiStore.slideModeDoubleClickBehavior}
       tabIndex={-1}
     />
   );

--- a/src/frontend/containers/ContentView/SlideMode.tsx
+++ b/src/frontend/containers/ContentView/SlideMode.tsx
@@ -279,8 +279,8 @@ const ZoomableImage: React.FC<IZoomableImageProps & React.HTMLAttributes<HTMLDiv
         ) : (
           <img
             src={currentImg.src}
-            width={currentImg.dimensions.width}
-            height={currentImg.dimensions.height}
+            width={currentImg.dimensions.width || undefined}
+            height={currentImg.dimensions.height || undefined}
             alt={`Image could not be loaded: ${src}`}
             onError={setLoadError}
           />

--- a/src/frontend/containers/ContentView/SlideMode/LICENSE
+++ b/src/frontend/containers/ContentView/SlideMode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 - Present Xovation Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -718,7 +718,7 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
 
   componentWillUnmount() {
     this.cancelAnimation();
-    this.imageRef.removeEventListener('touchmove', this.handleTouchMove);
+    this.imageRef?.removeEventListener('touchmove', this.handleTouchMove);
     window.removeEventListener('resize', this.handleWindowResize);
   }
 

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -45,11 +45,12 @@ export interface IPinchZoomPanProps {
   minScale: number;
   maxScale: number;
   position: 'topLeft' | 'center';
-  doubleTapBehavior: 'reset' | 'zoom';
+  doubleTapBehavior: 'reset' | 'zoom' | 'zoomOrReset' | 'close';
   initialTop?: number;
   initialLeft?: number;
   imageDimensions?: IDimensions;
   containerDimensions?: IDimensions;
+  onClose?: () => void;
   debug?: boolean;
 
   transitionStart?: ISlideTransform;
@@ -342,14 +343,21 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
   }
 
   doubleClick(pointerPosition: IVec2) {
+    const { doubleTapBehavior, onClose } = this.props;
+    if (doubleTapBehavior === 'close') return onClose?.();
     if (
-      String(this.props.doubleTapBehavior).toLowerCase() === 'zoom' &&
+      doubleTapBehavior === 'zoom' &&
       this.state.scale * (1 + OVERZOOM_TOLERANCE) < this.props.maxScale
     ) {
-      this.zoomIn(pointerPosition, ANIMATION_SPEED, 0.3);
-    } else {
-      //reset
+      return this.zoomIn(pointerPosition, ANIMATION_SPEED, 1);
+    }
+    if (doubleTapBehavior === 'reset') {
       this.applyInitialTransform(ANIMATION_SPEED);
+    }
+    if (doubleTapBehavior === 'zoomOrReset') {
+      this.state.scale * (1 + OVERZOOM_TOLERANCE) < this.props.maxScale
+        ? this.zoomIn(pointerPosition, ANIMATION_SPEED, 1)
+        : this.applyInitialTransform(ANIMATION_SPEED);
     }
   }
 

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -431,18 +431,21 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
         this.cancelAnimation();
 
         // Keep image centered when container dimensions change (e.g. closing a side bar)
-        const newLeft =
-          this.state.left - (this.state.containerDimensions.width - containerDimensions.width) / 2;
-        const newTop =
-          this.state.top - (this.state.containerDimensions.height - containerDimensions.height) / 2;
+        let newTransform: { left: number; top: number } | undefined = undefined;
+        const oldContainerDims = this.state.containerDimensions;
+        if (oldContainerDims.width !== 0 && oldContainerDims.height !== 0) {
+          newTransform = {
+            left: this.state.left - (oldContainerDims.width - containerDimensions.width) / 2,
+            top: this.state.top - (oldContainerDims.height - containerDimensions.height) / 2,
+          };
+        }
 
         //capture new dimensions
         this.setState(
           {
             containerDimensions,
             imageDimensions: imageDimensions!,
-            left: newLeft,
-            top: newTop,
+            ...(newTransform ? newTransform : ({} as ISlideTransform)),
           },
           () => {
             //When image loads and image dimensions are first established, apply initial transform.

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -1,6 +1,6 @@
 /**
  * Based on https://github.com/bradstiff/react-responsive-pinch-zoom-pan/tree/bc2b997febae37327ac5696433712371332645af/src
- * MIT license yada yada
+ * MIT license, see LICENSE file
  */
 
 import React, { ReactElement } from 'react';

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -1,0 +1,737 @@
+/**
+ * Based on https://github.com/bradstiff/react-responsive-pinch-zoom-pan/tree/bc2b997febae37327ac5696433712371332645af/src
+ * MIT license yada yada
+ */
+
+import React, { ReactElement } from 'react';
+import { createSelector } from 'reselect';
+
+import {
+  snapToTarget,
+  negate,
+  constrain,
+  getPinchLength,
+  getPinchMidpoint,
+  getRelativePosition,
+  setRef,
+  isEqualDimensions,
+  getDimensions,
+  getContainerDimensions,
+  isEqualTransform,
+  getAutofitScale,
+  getMinScale,
+  tryCancelEvent,
+  getImageOverflow,
+  IDimensions,
+  IVec2,
+  ITransform,
+} from './utils';
+
+const warning = (cond: boolean, msg: string) => !cond && console.warn(msg);
+
+const OVERZOOM_TOLERANCE = 0.05;
+const DOUBLE_TAP_THRESHOLD = 250;
+const ANIMATION_SPEED = 0.1;
+
+export interface IPinchZoomPanProps {
+  // children: React.ReactHTMLElement<HTMLImageElement>;
+  initialScale: number | 'auto';
+  minScale: number;
+  maxScale: number;
+  position: 'topLeft' | 'center';
+  doubleTapBehavior: 'reset' | 'zoom';
+  initialTop?: number;
+  initialLeft?: number;
+  imageDimensions?: IDimensions;
+  containerDimensions?: IDimensions;
+  debug?: boolean;
+
+  transitionStart?: { scale: number; left: number; top: number };
+}
+
+export interface IPinchZoomPanState {
+  top: number;
+  left: number;
+  scale: number;
+  imageDimensions: IDimensions;
+  containerDimensions: IDimensions;
+
+  initialTop?: number;
+  initialLeft?: number;
+  initialScale?: number;
+  position?: 'topLeft' | 'center';
+}
+
+const isInitialized = (top: number, left: number, scale: number) =>
+  !(scale === 0 && left === 0 && top === 0);
+
+const imageStyle = createSelector(
+  (state: IPinchZoomPanState) => state.top,
+  (state: IPinchZoomPanState) => state.left,
+  (state: IPinchZoomPanState) => state.scale,
+  (top, left, scale) => {
+    const style = {
+      cursor: 'pointer',
+    };
+    return isInitialized(top, left, scale)
+      ? {
+          ...style,
+          transform: `translate3d(${left}px, ${top}px, 0) scale(${scale})`,
+          transformOrigin: '0 0',
+        }
+      : style;
+  },
+);
+
+const imageOverflow = createSelector(
+  (state: IPinchZoomPanState) => state.top,
+  (state: IPinchZoomPanState) => state.left,
+  (state: IPinchZoomPanState) => state.scale,
+  (state: IPinchZoomPanState) => state.imageDimensions,
+  (state: IPinchZoomPanState) => state.containerDimensions,
+  (top, left, scale, imageDimensions, containerDimensions) => {
+    if (!isInitialized(top, left, scale)) {
+      return null;
+    }
+    return getImageOverflow(top, left, scale, imageDimensions, containerDimensions);
+  },
+);
+
+const browserPanActions = createSelector(imageOverflow, (imageOverflow) => {
+  //Determine the panning directions where there is no image overflow and let
+  //the browser handle those directions (e.g., scroll viewport if possible).
+  //Need to replace 'pan-left pan-right' with 'pan-x', etc. otherwise
+  //it is rejected (o_O), therefore explicitly handle each combination.
+  const browserPanX =
+    !imageOverflow?.left && !imageOverflow?.right
+      ? 'pan-x' //we can't pan the image horizontally, let the browser take it
+      : !imageOverflow.left
+      ? 'pan-left'
+      : !imageOverflow.right
+      ? 'pan-right'
+      : '';
+  const browserPanY =
+    !imageOverflow?.top && !imageOverflow?.bottom
+      ? 'pan-y'
+      : !imageOverflow.top
+      ? 'pan-up'
+      : !imageOverflow.bottom
+      ? 'pan-down'
+      : '';
+  return [browserPanX, browserPanY].join(' ').trim();
+});
+
+//Ensure the image is not over-panned, and not over- or under-scaled.
+//These constraints must be checked when image changes, and when container is resized.
+export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZoomPanState> {
+  static defaultProps = {
+    initialScale: 'auto',
+    minScale: 'auto',
+    maxScale: 1,
+    position: 'topLeft',
+    doubleTapBehavior: 'reset',
+  };
+
+  lastPointerUpTimeStamp: any; //enables detecting double-tap
+  lastPanPointerPosition: any; //helps determine how far to pan the image
+  lastPinchLength: any; //helps determine if we are pinching in or out
+  animation: any; //current animation handle
+  imageRef: any; //image element
+  isImageLoaded: any; //permits initial transform
+  originalOverscrollBehaviorY: any; //saves the original overscroll-behavior-y value while temporarily preventing pull down refresh
+  isTransformInitialized?: boolean;
+  initialTransitionFinished?: boolean;
+
+  constructor(props: IPinchZoomPanProps) {
+    super(props);
+    this.state = {
+      imageDimensions: props.imageDimensions || { width: 0, height: 0 },
+      containerDimensions: { width: 0, height: 0 },
+      ...(props.transitionStart || { top: 0, left: 0, scale: 0 }),
+    };
+  }
+
+  //event handlers
+  handleTouchStart = (event: TouchEvent) => {
+    this.cancelAnimation();
+
+    const touches = event.touches;
+    if (touches.length === 2) {
+      this.lastPinchLength = getPinchLength(touches);
+      this.lastPanPointerPosition = null;
+    } else if (touches.length === 1) {
+      this.lastPinchLength = null;
+      this.pointerDown(touches[0]);
+      tryCancelEvent(event); //suppress mouse events
+    }
+  };
+
+  handleTouchMove = (event: TouchEvent) => {
+    const touches = event.touches;
+    if (touches.length === 2) {
+      this.pinchChange(touches);
+
+      //suppress viewport scaling on iOS
+      tryCancelEvent(event);
+    } else if (touches.length === 1) {
+      const requestedPan = this.pan(touches.item(0)!);
+
+      if (requestedPan && !this.controlOverscrollViaCss) {
+        //let the browser handling panning if we are at the edge of the image in
+        //both pan directions, or if we are primarily panning in one direction
+        //and are at the edge in that directino
+        const overflow = imageOverflow(this.state);
+        if (!overflow) return;
+        const hasOverflowX =
+          (requestedPan.left && overflow.left > 0) || (requestedPan.right && overflow.right > 0);
+        const hasOverflowY =
+          (requestedPan.up && overflow.top > 0) || (requestedPan.down && overflow.bottom > 0);
+
+        if (!hasOverflowX && !hasOverflowY) {
+          //no overflow in both directions
+          return;
+        }
+
+        const panX = requestedPan.left || requestedPan.right;
+        const panY = requestedPan.up || requestedPan.down;
+        if (panY > 2 * panX && !hasOverflowY) {
+          //primarily panning up or down and no overflow in the Y direction
+          return;
+        }
+
+        if (panX > 2 * panY && !hasOverflowX) {
+          //primarily panning left or right and no overflow in the X direction
+          return;
+        }
+
+        tryCancelEvent(event);
+      }
+    }
+  };
+
+  handleTouchEnd = (event: TouchEvent) => {
+    this.cancelAnimation();
+    if (event.touches.length === 0 && event.changedTouches.length === 1) {
+      if (
+        this.lastPointerUpTimeStamp &&
+        this.lastPointerUpTimeStamp + DOUBLE_TAP_THRESHOLD > event.timeStamp
+      ) {
+        const pointerPosition = getRelativePosition(
+          event.changedTouches[0],
+          this.imageRef.parentNode,
+        );
+        this.doubleClick(pointerPosition);
+      }
+      this.lastPointerUpTimeStamp = event.timeStamp;
+      tryCancelEvent(event); //suppress mouse events
+    }
+
+    //We allow transient +/-5% over-pinching.
+    //Animate the bounce back to constraints if applicable.
+    this.maybeAdjustCurrentTransform(ANIMATION_SPEED);
+    return;
+  };
+
+  handleMouseDown = (event: MouseEvent) => {
+    this.cancelAnimation();
+    this.pointerDown(event);
+  };
+
+  handleMouseMove = (event: MouseEvent) => {
+    if (!event.buttons) return null;
+    this.pan(event);
+  };
+
+  handleMouseDoubleClick = (event: MouseEvent) => {
+    this.cancelAnimation();
+    const pointerPosition = getRelativePosition(event, this.imageRef.parentNode);
+    this.doubleClick(pointerPosition);
+  };
+
+  handleMouseWheel = (event: WheelEvent) => {
+    this.cancelAnimation();
+    const point = getRelativePosition(event, this.imageRef.parentNode);
+    if (event.deltaY > 0) {
+      if (this.state.scale > getMinScale(this.state, this.props)) {
+        this.zoomOut(point);
+        tryCancelEvent(event);
+      }
+    } else if (event.deltaY < 0) {
+      if (this.state.scale < this.props.maxScale) {
+        this.zoomIn(point);
+        tryCancelEvent(event);
+      }
+    }
+  };
+
+  handleImageLoad = (event: React.ReactEventHandler<HTMLImageElement>) => {
+    this.debug('handleImageLoad');
+    this.isImageLoaded = true;
+    this.maybeHandleDimensionsChanged();
+
+    const { onLoad } = React.Children.only(this.props.children as any).props;
+    if (typeof onLoad === 'function') {
+      onLoad(event);
+    }
+  };
+
+  handleZoomInClick = () => {
+    this.cancelAnimation();
+    this.zoomIn();
+  };
+
+  handleZoomOutClick = () => {
+    this.cancelAnimation();
+    this.zoomOut();
+  };
+
+  handleWindowResize = () => this.maybeHandleDimensionsChanged();
+
+  handleRefImage = (ref: React.Ref<HTMLImageElement>) => {
+    if (this.imageRef) {
+      this.cancelAnimation();
+      this.imageRef.removeEventListener('touchmove', this.handleTouchMove);
+    }
+
+    this.imageRef = ref;
+    if (ref) {
+      this.imageRef.addEventListener('touchmove', this.handleTouchMove, { passive: false });
+    }
+
+    const { ref: imageRefProp } = React.Children.only(this.props.children) as any;
+    setRef(imageRefProp, ref);
+  };
+
+  //actions
+  pointerDown(clientPosition: Touch | MouseEvent) {
+    this.lastPanPointerPosition = getRelativePosition(clientPosition, this.imageRef.parentNode);
+  }
+
+  pan(pointerClientPosition: MouseEvent | Touch) {
+    if (!this.isTransformInitialized) {
+      return;
+    }
+
+    if (!this.lastPanPointerPosition) {
+      //if we were pinching and lifted a finger
+      this.pointerDown(pointerClientPosition);
+      return 0;
+    }
+
+    const pointerPosition = getRelativePosition(pointerClientPosition, this.imageRef.parentNode);
+    const translateX = pointerPosition.x - this.lastPanPointerPosition.x;
+    const translateY = pointerPosition.y - this.lastPanPointerPosition.y;
+    this.lastPanPointerPosition = pointerPosition;
+
+    const top = this.state.top + translateY;
+    const left = this.state.left + translateX;
+    this.constrainAndApplyTransform(top, left, this.state.scale, 0, 0);
+
+    return {
+      up: translateY > 0 ? translateY : 0,
+      down: translateY < 0 ? negate(translateY) : 0,
+      right: translateX < 0 ? negate(translateX) : 0,
+      left: translateX > 0 ? translateX : 0,
+    };
+  }
+
+  doubleClick(pointerPosition: IVec2) {
+    if (
+      String(this.props.doubleTapBehavior).toLowerCase() === 'zoom' &&
+      this.state.scale * (1 + OVERZOOM_TOLERANCE) < this.props.maxScale
+    ) {
+      this.zoomIn(pointerPosition, ANIMATION_SPEED, 0.3);
+    } else {
+      //reset
+      this.applyInitialTransform(ANIMATION_SPEED);
+    }
+  }
+
+  pinchChange(touches: TouchList) {
+    const length = getPinchLength(touches);
+    const midpoint = getPinchMidpoint(touches);
+    const scale = this.lastPinchLength
+      ? (this.state.scale * length) / this.lastPinchLength //sometimes we get a touchchange before a touchstart when pinching
+      : this.state.scale;
+
+    this.zoom(scale, midpoint, OVERZOOM_TOLERANCE);
+
+    this.lastPinchLength = length;
+  }
+
+  zoomIn(midpoint?: IVec2, speed = 0, factor = 0.1) {
+    midpoint = midpoint || {
+      x: this.state.containerDimensions.width / 2,
+      y: this.state.containerDimensions.height / 2,
+    };
+    this.zoom(this.state.scale * (1 + factor), midpoint, 0, speed);
+  }
+
+  zoomOut(midpoint?: IVec2) {
+    midpoint = midpoint || {
+      x: this.state.containerDimensions.width / 2,
+      y: this.state.containerDimensions.height / 2,
+    };
+    this.zoom(this.state.scale * 0.9, midpoint, 0);
+  }
+
+  zoom(requestedScale: number, containerRelativePoint: IVec2, tolerance: number, speed = 0) {
+    if (!this.isTransformInitialized) {
+      return;
+    }
+
+    const { scale, top, left } = this.state;
+    const imageRelativePoint = {
+      top: containerRelativePoint.y - top,
+      left: containerRelativePoint.x - left,
+    };
+
+    const nextScale = this.getConstrainedScale(requestedScale, tolerance);
+    const incrementalScalePercentage = (nextScale - scale) / scale;
+    const translateY = imageRelativePoint.top * incrementalScalePercentage;
+    const translateX = imageRelativePoint.left * incrementalScalePercentage;
+
+    const nextTop = top - translateY;
+    const nextLeft = left - translateX;
+
+    this.constrainAndApplyTransform(nextTop, nextLeft, nextScale, tolerance, speed);
+  }
+
+  //compare stored dimensions to actual dimensions; capture actual dimensions if different
+  maybeHandleDimensionsChanged() {
+    // if img resolution is provided, no need to wait for img load before transform
+    if (this.isImageReady || this.props.imageDimensions) {
+      const containerDimensions =
+        this.props.containerDimensions || getContainerDimensions(this.imageRef);
+      // a lil finnicky for initaial transition: dimensions need to be known asap then
+      // but later, get from image since otherwise you get flicker when vhanging images
+      const imageDimensions = !this.initialTransitionFinished
+        ? this.props.imageDimensions || getDimensions(this.imageRef)
+        : getDimensions(this.imageRef);
+
+      const imgDimensionsChanged = !isEqualDimensions(
+        imageDimensions,
+        getDimensions(this.state.imageDimensions),
+      );
+      const containerDimensionsChanged = !isEqualDimensions(
+        containerDimensions,
+        getDimensions(this.state.containerDimensions),
+      );
+      if (imgDimensionsChanged || containerDimensionsChanged) {
+        this.cancelAnimation();
+
+        //capture new dimensions
+        this.setState(
+          {
+            containerDimensions,
+            imageDimensions: imageDimensions!,
+          },
+          () => {
+            //When image loads and image dimensions are first established, apply initial transform.
+            //If dimensions change, constraints change; current transform may need to be adjusted.
+            //Transforms depend on state, so wait until state is updated.
+            if (!this.isTransformInitialized) {
+              this.applyInitialTransform(this.props.transitionStart ? ANIMATION_SPEED : 0);
+              this.isTransformInitialized = true;
+            } else {
+              // apply initial transform when image changes
+              imgDimensionsChanged
+                ? this.applyInitialTransform()
+                : this.maybeAdjustCurrentTransform();
+            }
+          },
+        );
+        this.debug(
+          `Dimensions changed: Container: ${containerDimensions.width}, ${containerDimensions.height}, Image: ${imageDimensions?.width}, ${imageDimensions?.height}`,
+        );
+      }
+    } else {
+      this.debug('Image not loaded');
+    }
+  }
+
+  //transformation methods
+
+  //Zooming and panning cause transform to be requested.
+  constrainAndApplyTransform(
+    requestedTop: number,
+    requestedLeft: number,
+    requestedScale: number,
+    tolerance: number,
+    speed = 0,
+  ) {
+    const requestedTransform = {
+      top: requestedTop,
+      left: requestedLeft,
+      scale: requestedScale,
+    };
+    this.debug(
+      `Requesting transform: left ${requestedLeft}, top ${requestedTop}, scale ${requestedScale}`,
+    );
+
+    //Correct the transform if needed to prevent overpanning and overzooming
+    const transform = !this.isTransformInitialized
+      ? requestedTransform
+      : this.getCorrectedTransform(requestedTransform, tolerance) || requestedTransform;
+    this.debug(
+      `Applying transform: left ${transform.left}, top ${transform.top}, scale ${transform.scale}`,
+    );
+
+    if (isEqualTransform(transform, this.state)) {
+      return false;
+    }
+
+    this.applyTransform(transform, speed);
+    return true;
+  }
+
+  applyTransform({ top, left, scale }: ITransform, speed: number) {
+    if (speed > 0) {
+      const frame = () => {
+        const translateY = top - this.state.top;
+        const translateX = left - this.state.left;
+        const translateScale = scale - this.state.scale;
+
+        const nextTransform = {
+          top: snapToTarget(this.state.top + speed * translateY, top, 1),
+          left: snapToTarget(this.state.left + speed * translateX, left, 1),
+          scale: snapToTarget(this.state.scale + speed * translateScale, scale, 0.001),
+        };
+
+        //animation runs until we reach the target
+        if (!isEqualTransform(nextTransform, this.state)) {
+          this.setState(nextTransform, () => (this.animation = requestAnimationFrame(frame)));
+        } else if (!this.initialTransitionFinished) {
+          this.initialTransitionFinished = true;
+        }
+      };
+      this.animation = requestAnimationFrame(frame);
+    } else {
+      this.setState({
+        top,
+        left,
+        scale,
+      });
+    }
+  }
+
+  //Returns constrained scale when requested scale is outside min/max with tolerance, otherwise returns requested scale
+  getConstrainedScale(requestedScale: number, tolerance: number) {
+    const lowerBoundFactor = 1.0 - tolerance;
+    const upperBoundFactor = 1.0 + tolerance;
+
+    return constrain(
+      getMinScale(this.state, this.props) * lowerBoundFactor,
+      this.props.maxScale * upperBoundFactor,
+      requestedScale,
+    );
+  }
+
+  //Returns constrained transform when requested transform is outside constraints with tolerance, otherwise returns null
+  getCorrectedTransform(requestedTransform: ITransform, tolerance: number) {
+    const scale = this.getConstrainedScale(requestedTransform.scale, tolerance);
+
+    //get dimensions by which scaled image overflows container
+    const negativeSpace = this.calculateNegativeSpace(scale);
+    const overflow = {
+      width: Math.max(0, negate(negativeSpace.width)),
+      height: Math.max(0, negate(negativeSpace.height)),
+    };
+
+    //if image overflows container, prevent moving by more than the overflow
+    //example: overflow.height = 100, tolerance = 0.05 => top is constrained between -105 and +5
+    const { position, initialTop, initialLeft } = this.props;
+    const { imageDimensions, containerDimensions } = this.state;
+    const upperBoundFactor = 1.0 + tolerance;
+    const top = overflow.height
+      ? constrain(
+          negate(overflow.height) * upperBoundFactor,
+          overflow.height * upperBoundFactor - overflow.height,
+          requestedTransform.top,
+        )
+      : position === 'center'
+      ? (containerDimensions.height - imageDimensions.height * scale) / 2
+      : initialTop || 0;
+
+    const left = overflow.width
+      ? constrain(
+          negate(overflow.width) * upperBoundFactor,
+          overflow.width * upperBoundFactor - overflow.width,
+          requestedTransform.left,
+        )
+      : position === 'center'
+      ? (containerDimensions.width - imageDimensions.width * scale) / 2
+      : initialLeft || 0;
+
+    const constrainedTransform = {
+      top,
+      left,
+      scale,
+    };
+
+    return isEqualTransform(constrainedTransform, requestedTransform) ? null : constrainedTransform;
+  }
+
+  //Ensure current transform is within constraints
+  maybeAdjustCurrentTransform(speed = 0) {
+    let correctedTransform;
+    if ((correctedTransform = this.getCorrectedTransform(this.state, 0))) {
+      this.applyTransform(correctedTransform, speed);
+    }
+  }
+
+  applyInitialTransform(speed = 0) {
+    const { imageDimensions, containerDimensions } = this.state;
+    const { position, initialScale, maxScale, initialTop, initialLeft } = this.props;
+
+    const scale =
+      String(initialScale).toLowerCase() === 'auto'
+        ? getAutofitScale(containerDimensions, imageDimensions)
+        : (initialScale as number);
+    const minScale = getMinScale(this.state, this.props);
+
+    if (minScale > maxScale) {
+      warning(false, 'minScale cannot exceed maxScale.');
+      return;
+    }
+    if (scale < minScale || scale > maxScale) {
+      warning(false, 'initialScale must be between minScale and maxScale.');
+      return;
+    }
+
+    let initialPosition;
+    // if (!this.isTransformInitialized) {
+    //   initialPosition = this.state;
+    // } else
+    if (position === 'center') {
+      warning(
+        initialTop === undefined,
+        'initialTop prop should not be supplied with position=center. It was ignored.',
+      );
+      warning(
+        initialLeft === undefined,
+        'initialLeft prop should not be supplied with position=center. It was ignored.',
+      );
+      initialPosition = {
+        left: (containerDimensions.width - imageDimensions.width * scale) / 2,
+        top: (containerDimensions.height - imageDimensions.height * scale) / 2,
+      };
+    } else {
+      initialPosition = {
+        top: initialTop || 0,
+        left: initialLeft || 0,
+      };
+    }
+
+    const tolerance = 1;
+    this.constrainAndApplyTransform(
+      initialPosition.top,
+      initialPosition.left,
+      scale,
+      tolerance,
+      speed,
+    );
+  }
+
+  //lifecycle methods
+  render() {
+    const childElement = React.Children.only(this.props.children);
+
+    const touchAction = this.controlOverscrollViaCss
+      ? browserPanActions(this.state) || 'none'
+      : undefined;
+
+    const containerStyle = {
+      width: '100%',
+      height: '100%',
+      overflow: 'hidden',
+      touchAction: touchAction,
+    };
+
+    return (
+      <div style={containerStyle}>
+        {React.cloneElement(childElement as ReactElement, {
+          onTouchStart: this.handleTouchStart,
+          onTouchEnd: this.handleTouchEnd,
+          onMouseDown: this.handleMouseDown,
+          onMouseMove: this.handleMouseMove,
+          onDoubleClick: this.handleMouseDoubleClick,
+          onWheel: this.handleMouseWheel,
+          onDragStart: tryCancelEvent,
+          onLoad: this.handleImageLoad,
+          onContextMenu: tryCancelEvent,
+          ref: this.handleRefImage,
+          style: imageStyle(this.state),
+        })}
+      </div>
+    );
+  }
+
+  static getDerivedStateFromProps(nextProps: IPinchZoomPanProps, prevState: IPinchZoomPanState) {
+    if (
+      nextProps.initialTop !== prevState.initialTop ||
+      nextProps.initialLeft !== prevState.initialLeft ||
+      nextProps.initialScale !== prevState.initialScale ||
+      nextProps.position !== prevState.position
+    ) {
+      return {
+        position: nextProps.position,
+        initialScale: nextProps.initialScale,
+        initialTop: nextProps.initialTop,
+        initialLeft: nextProps.initialLeft,
+      };
+    } else {
+      return null;
+    }
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleWindowResize);
+    this.maybeHandleDimensionsChanged();
+  }
+
+  componentDidUpdate() {
+    this.maybeHandleDimensionsChanged();
+  }
+
+  componentWillUnmount() {
+    this.cancelAnimation();
+    this.imageRef.removeEventListener('touchmove', this.handleTouchMove);
+    window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  get isImageReady() {
+    return this.isImageLoaded || (this.imageRef && this.imageRef.tagName !== 'IMG');
+  }
+
+  // get isTransformInitialized() {
+  //   return isInitialized(this.state.top, this.state.left, this.state.scale);
+  // }
+
+  get controlOverscrollViaCss() {
+    return window.CSS && window.CSS.supports('touch-action', 'pan-up');
+  }
+
+  calculateNegativeSpace(scale: number) {
+    //get difference in dimension between container and scaled image
+    const { containerDimensions, imageDimensions } = this.state;
+    const width = containerDimensions.width - scale * imageDimensions.width;
+    const height = containerDimensions.height - scale * imageDimensions.height;
+    return {
+      width,
+      height,
+    };
+  }
+
+  cancelAnimation() {
+    if (this.animation) {
+      cancelAnimationFrame(this.animation);
+    }
+  }
+
+  debug(message: string) {
+    if (this.props.debug) {
+      console.log(message);
+    }
+  }
+}

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -140,7 +140,6 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
   isImageLoaded: any; //permits initial transform
   originalOverscrollBehaviorY: any; //saves the original overscroll-behavior-y value while temporarily preventing pull down refresh
   isTransformInitialized?: boolean;
-  initialTransitionFinished?: boolean;
 
   constructor(props: IPinchZoomPanProps) {
     super(props);
@@ -405,9 +404,7 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
         this.props.containerDimensions || getContainerDimensions(this.imageRef);
       // a lil finnicky for initaial transition: dimensions need to be known asap then
       // but later, get from image since otherwise you get flicker when vhanging images
-      const imageDimensions = !this.initialTransitionFinished
-        ? this.props.imageDimensions || getDimensions(this.imageRef)
-        : getDimensions(this.imageRef);
+      const imageDimensions = this.props.imageDimensions || getDimensions(this.imageRef);
 
       const imgDimensionsChanged = !isEqualDimensions(
         imageDimensions,
@@ -501,8 +498,6 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
         //animation runs until we reach the target
         if (!isEqualTransform(nextTransform, this.state)) {
           this.setState(nextTransform, () => (this.animation = requestAnimationFrame(frame)));
-        } else if (!this.initialTransitionFinished) {
-          this.initialTransitionFinished = true;
         }
       };
       this.animation = requestAnimationFrame(frame);

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -355,7 +355,12 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
       this.applyInitialTransform(ANIMATION_SPEED);
     }
     if (doubleTapBehavior === 'zoomOrReset') {
-      this.state.scale * (1 + OVERZOOM_TOLERANCE) < this.props.maxScale
+      const initialScale = getAutofitScale(
+        this.state.containerDimensions,
+        this.state.imageDimensions,
+      );
+      // If current scale is same as initial scale, zoom in, otherwise reset to initial zoom
+      Math.abs(this.state.scale - initialScale) < 0.01
         ? this.zoomIn(pointerPosition, ANIMATION_SPEED, 1)
         : this.applyInitialTransform(ANIMATION_SPEED);
     }

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -430,11 +430,19 @@ export default class ZoomPan extends React.Component<IPinchZoomPanProps, IPinchZ
       if (imgDimensionsChanged || containerDimensionsChanged) {
         this.cancelAnimation();
 
+        // Keep image centered when container dimensions change (e.g. closing a side bar)
+        const newLeft =
+          this.state.left - (this.state.containerDimensions.width - containerDimensions.width) / 2;
+        const newTop =
+          this.state.top - (this.state.containerDimensions.height - containerDimensions.height) / 2;
+
         //capture new dimensions
         this.setState(
           {
             containerDimensions,
             imageDimensions: imageDimensions!,
+            left: newLeft,
+            top: newTop,
           },
           () => {
             //When image loads and image dimensions are first established, apply initial transform.

--- a/src/frontend/containers/ContentView/SlideMode/utils.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/utils.tsx
@@ -1,6 +1,6 @@
 /**
  * Based on https://github.com/bradstiff/react-responsive-pinch-zoom-pan/tree/bc2b997febae37327ac5696433712371332645af/src
- * MIT license yada yada
+ * MIT license, see LICENSE file
  */
 
 import { createSelector } from 'reselect';

--- a/src/frontend/containers/ContentView/SlideMode/utils.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/utils.tsx
@@ -1,0 +1,192 @@
+/**
+ * Based on https://github.com/bradstiff/react-responsive-pinch-zoom-pan/tree/bc2b997febae37327ac5696433712371332645af/src
+ * MIT license yada yada
+ */
+
+import { createSelector } from 'reselect';
+import { IPinchZoomPanProps, IPinchZoomPanState } from './ZoomPan';
+
+export interface IDimensions {
+  width: number;
+  height: number;
+}
+
+export interface IVec2 {
+  x: number;
+  y: number;
+}
+
+export interface ITransform {
+  top: number;
+  left: number;
+  scale: number;
+}
+
+export const snapToTarget = (value: number, target: number, tolerance: number) => {
+  const withinRange = Math.abs(target - value) < tolerance;
+  return withinRange ? target : value;
+};
+
+export const constrain = (lowerBound: number, upperBound: number, value: number) =>
+  Math.min(upperBound, Math.max(lowerBound, value));
+
+export const negate = (value: number) => value * -1;
+
+export const getRelativePosition = (
+  { clientX, clientY }: MouseEvent | Touch,
+  relativeToElement: { getBoundingClientRect: () => any },
+) => {
+  const rect = relativeToElement.getBoundingClientRect();
+  return {
+    x: clientX - rect.left,
+    y: clientY - rect.top,
+  };
+};
+
+export const getPinchMidpoint = ([touch1, touch2]: any) => ({
+  x: (touch1.clientX + touch2.clientX) / 2,
+  y: (touch1.clientY + touch2.clientY) / 2,
+});
+
+export const getPinchLength = ([touch1, touch2]: any) =>
+  Math.sqrt(
+    Math.pow(touch1.clientY - touch2.clientY, 2) + Math.pow(touch1.clientX - touch2.clientX, 2),
+  );
+
+export function setRef(ref: any, value: any) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+export const isEqualDimensions = (dimensions1?: IDimensions, dimensions2?: IDimensions) => {
+  if ((dimensions1 === dimensions2) === undefined) {
+    return true;
+  }
+  if (dimensions1 === undefined || dimensions2 === undefined) {
+    return false;
+  }
+  return dimensions1.width === dimensions2.width && dimensions1.height === dimensions2.height;
+};
+
+export const getDimensions = (object: any): IDimensions | undefined => {
+  if (object === undefined) {
+    return undefined;
+  }
+  return {
+    width: object.offsetWidth || object.width,
+    height: object.offsetHeight || object.height,
+  };
+};
+
+export const getContainerDimensions = (image: any) => {
+  return {
+    width: image.parentNode.offsetWidth,
+    height: image.parentNode.offsetHeight,
+  };
+};
+
+export const isEqualTransform = (transform1: ITransform, transform2: ITransform) => {
+  if ((transform1 === transform2) === undefined) {
+    return true;
+  }
+  if (transform1 === undefined || transform2 === undefined) {
+    return false;
+  }
+  return (
+    round(transform1.top, 5) === round(transform2.top, 5) &&
+    round(transform1.left, 5) === round(transform2.left, 5) &&
+    round(transform1.scale, 5) === round(transform2.scale, 5)
+  );
+};
+
+export const getAutofitScale = (containerDimensions: IDimensions, imageDimensions: IDimensions) => {
+  const { width: imageWidth, height: imageHeight } = imageDimensions || {};
+  if (!(imageWidth > 0 && imageHeight > 0)) {
+    return 1;
+  }
+  return Math.min(
+    containerDimensions.width / imageWidth,
+    containerDimensions.height / imageHeight,
+    1,
+  );
+};
+
+export const getMinScale = createSelector(
+  (state: IPinchZoomPanState) => state.containerDimensions,
+  (state: IPinchZoomPanState) => state.imageDimensions,
+  (state: IPinchZoomPanState, props: IPinchZoomPanProps) => props.minScale,
+  (containerDimensions, imageDimensions, minScaleProp) =>
+    String(minScaleProp).toLowerCase() === 'auto'
+      ? getAutofitScale(containerDimensions, imageDimensions)
+      : minScaleProp || 1,
+);
+
+function round(number: number, precision?: number) {
+  if (precision && number !== null && number !== undefined) {
+    // Shift with exponential notation to avoid floating-point issues.
+    // See [MDN](https://mdn.io/round#Examples) for more details.
+    let pair = (String(number) + 'e').split('e');
+    const value = Math.round(Number(`${pair[0]}e${+pair[1] + precision}`));
+
+    pair = (String(value) + 'e').split('e');
+    return +(pair[0] + 'e' + (+pair[1] - precision));
+  }
+  return Math.round(number);
+}
+
+export const tryCancelEvent = (event: Event) => {
+  if (event.cancelable === false) {
+    return false;
+  }
+
+  event.preventDefault();
+  return true;
+};
+
+function calculateOverflowLeft(left: number) {
+  const overflow = negate(left);
+  return overflow > 0 ? overflow : 0;
+}
+
+function calculateOverflowTop(top: number) {
+  const overflow = negate(top);
+  return overflow > 0 ? overflow : 0;
+}
+
+function calculateOverflowRight(
+  left: number,
+  scale: number,
+  imageDimensions: IDimensions,
+  containerDimensions: IDimensions,
+) {
+  const overflow = Math.max(0, scale * imageDimensions.width - containerDimensions.width);
+  return overflow > 0 ? overflow - negate(left) : 0;
+}
+
+function calculateOverflowBottom(
+  top: number,
+  scale: number,
+  imageDimensions: IDimensions,
+  containerDimensions: IDimensions,
+) {
+  const overflow = Math.max(0, scale * imageDimensions.height - containerDimensions.height);
+  return overflow > 0 ? overflow - negate(top) : 0;
+}
+
+export const getImageOverflow = (
+  top: number,
+  left: number,
+  scale: number,
+  imageDimensions: IDimensions,
+  containerDimensions: IDimensions,
+) => {
+  return {
+    top: calculateOverflowTop(top),
+    right: calculateOverflowRight(left, scale, imageDimensions, containerDimensions),
+    bottom: calculateOverflowBottom(top, scale, imageDimensions, containerDimensions),
+    left: calculateOverflowLeft(left),
+  };
+};

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -26,6 +26,7 @@ export const FileViewerMenuItems = ({ file }: { file: ClientFile }) => {
 
   const handleViewFullSize = () => {
     uiStore.selectFile(file, true);
+    uiStore.enableSlideMode();
   };
 
   const handlePreviewWindow = () => {

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -26,7 +26,6 @@ export const FileViewerMenuItems = ({ file }: { file: ClientFile }) => {
 
   const handleViewFullSize = () => {
     uiStore.selectFile(file, true);
-    // uiStore.enableSlideMode({});
   };
 
   const handlePreviewWindow = () => {

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -24,7 +24,7 @@ export const MissingFileMenuItems = observer(
 export const FileViewerMenuItems = ({ file, uiStore }: { file: ClientFile; uiStore: UiStore }) => {
   const handleViewFullSize = () => {
     uiStore.selectFile(file, true);
-    uiStore.toggleSlideMode();
+    // uiStore.enableSlideMode({});
   };
 
   const handlePreviewWindow = () => {

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -424,16 +424,34 @@ const BackgroundProcesses = observer(() => {
   );
 });
 
-const Shortcuts = () => (
-  <>
-    <h2>Keyboard shortcuts</h2>
-    <p>
-      Click on a key combination to modify it. After typing your new combination, press Enter to
-      confirm or Escape to cancel.
-    </p>
-    <HotkeyMapper />
-  </>
-);
+const Shortcuts = observer(() => {
+  const { uiStore } = useContext(StoreContext);
+  return (
+    <>
+      <h2>Click behavior</h2>
+      <RadioGroup name="Slide mode double click">
+        <Radio
+          label="Zoom in/out"
+          value="zoomOrReset"
+          checked={uiStore.slideModeDoubleClickBehavior === 'zoomOrReset'}
+          onChange={uiStore.setSlideModeDoubleClickBehaviorZoomOrReset}
+        />
+        <Radio
+          label="Return to gallery"
+          value="close"
+          checked={uiStore.slideModeDoubleClickBehavior === 'close'}
+          onChange={uiStore.setSlideModeDoubleClickBehaviorClose}
+        />
+      </RadioGroup>
+      <h2>Keyboard shortcuts</h2>
+      <p>
+        Click on a key combination to modify it. After typing your new combination, press Enter to
+        confirm or Escape to cancel.
+      </p>
+      <HotkeyMapper />
+    </>
+  );
+});
 
 const Advanced = observer(() => {
   const { uiStore, fileStore } = useContext(StoreContext);

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -425,24 +425,8 @@ const BackgroundProcesses = observer(() => {
 });
 
 const Shortcuts = observer(() => {
-  const { uiStore } = useStore();
   return (
     <>
-      <h2>Click behavior</h2>
-      <RadioGroup name="Slide mode double click">
-        <Radio
-          label="Zoom in/out"
-          value="zoomOrReset"
-          checked={uiStore.slideModeDoubleClickBehavior === 'zoomOrReset'}
-          onChange={uiStore.setSlideModeDoubleClickBehaviorZoomOrReset}
-        />
-        <Radio
-          label="Return to gallery"
-          value="close"
-          checked={uiStore.slideModeDoubleClickBehavior === 'close'}
-          onChange={uiStore.setSlideModeDoubleClickBehaviorClose}
-        />
-      </RadioGroup>
       <h2>Keyboard shortcuts</h2>
       <p>
         Click on a key combination to modify it. After typing your new combination, press Enter to

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -425,7 +425,7 @@ const BackgroundProcesses = observer(() => {
 });
 
 const Shortcuts = observer(() => {
-  const { uiStore } = useContext(StoreContext);
+  const { uiStore } = useStore();
   return (
     <>
       <h2>Click behavior</h2>

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -97,7 +97,6 @@ const PersistentPreferenceFields: Array<keyof UiStore> = [
   'method',
   'thumbnailSize',
   'thumbnailShape',
-  'slideModeDoubleClickBehavior',
   'hotkeyMap',
   'isThumbnailTagOverlayEnabled',
   'isThumbnailFilenameOverlayEnabled',
@@ -128,7 +127,6 @@ class UiStore {
   @observable searchMatchAny = false;
   @observable method: ViewMethod = ViewMethod.Grid;
   @observable isSlideMode: boolean = false;
-  @observable slideModeDoubleClickBehavior: 'zoomOrReset' | 'close' = 'zoomOrReset';
   @observable isFullScreen: boolean = false;
   @observable outlinerWidth: number = UiStore.MIN_OUTLINER_WIDTH;
   @observable inspectorWidth: number = UiStore.MIN_INSPECTOR_WIDTH;
@@ -243,18 +241,6 @@ class UiStore {
 
   @action.bound toggleSlideMode() {
     this.isSlideMode = !this.isSlideMode;
-  }
-
-  @action.bound setSlideModeDoubleClickBehavior(val: 'zoomOrReset' | 'close') {
-    this.slideModeDoubleClickBehavior = val;
-  }
-
-  @action.bound setSlideModeDoubleClickBehaviorZoomOrReset() {
-    this.slideModeDoubleClickBehavior = 'zoomOrReset';
-  }
-
-  @action.bound setSlideModeDoubleClickBehaviorClose() {
-    this.slideModeDoubleClickBehavior = 'close';
   }
 
   /** This does not actually set the window to full-screen, just for bookkeeping! Use RendererMessenger instead */
@@ -727,8 +713,6 @@ class UiStore {
         if (prefs.thumbnailDirectory) this.setThumbnailDirectory(prefs.thumbnailDirectory);
         if (prefs.importDirectory) this.setImportDirectory(prefs.importDirectory);
         if (prefs.method) this.setMethod(prefs.method);
-        if (prefs.slideModeDoubleClickBehavior)
-          this.setSlideModeDoubleClickBehavior(prefs.slideModeDoubleClickBehavior);
         if (prefs.thumbnailSize) this.setThumbnailSize(prefs.thumbnailSize);
         if (prefs.thumbnailShape) this.setThumbnailShape(prefs.thumbnailShape);
         this.isThumbnailTagOverlayEnabled = Boolean(prefs.isThumbnailTagOverlayEnabled ?? true);

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -43,13 +43,16 @@ backend
   .catch((err) => console.error('Could not initialize backend!', err));
 
 if (IS_PREVIEW_WINDOW) {
-  RendererMessenger.onReceivePreviewFiles(({ ids, thumbnailDirectory, activeImgId }) => {
-    rootStore.uiStore.setFirstItem((activeImgId && ids.indexOf(activeImgId)) || 0);
-    rootStore.uiStore.setThumbnailDirectory(thumbnailDirectory);
-    rootStore.uiStore.enableSlideMode();
-    rootStore.uiStore.isInspectorOpen && rootStore.uiStore.toggleInspector();
-    rootStore.fileStore.fetchFilesByIDs(ids);
-  });
+  RendererMessenger.onReceivePreviewFiles(
+    ({ ids, thumbnailDirectory, viewMethod, activeImgId }) => {
+      rootStore.uiStore.setFirstItem((activeImgId && ids.indexOf(activeImgId)) || 0);
+      rootStore.uiStore.setThumbnailDirectory(thumbnailDirectory);
+      rootStore.uiStore.setMethod(viewMethod);
+      rootStore.uiStore.enableSlideMode();
+      rootStore.uiStore.isInspectorOpen && rootStore.uiStore.toggleInspector();
+      rootStore.fileStore.fetchFilesByIDs(ids);
+    },
+  );
 
   // Close preview with space
   window.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/widgets/Split/index.tsx
+++ b/widgets/Split/index.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 
 interface ISplit {
   id?: string;
+  className?: string;
   primary: React.ReactElement;
   secondary: React.ReactElement;
   axis: 'horizontal' | 'vertical';
@@ -17,6 +18,7 @@ interface ISplit {
 
 export const Split = ({
   id,
+  className,
   primary,
   secondary,
   axis,
@@ -111,7 +113,7 @@ export const Split = ({
   }, []);
 
   return (
-    <div ref={container} id={id} className="split" onMouseMove={handleMouseMove}>
+    <div ref={container} id={id} className={`split ${className}`} onMouseMove={handleMouseMove}>
       {primary}
       <div
         role="separator"

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,32 +978,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.30":
-  version "0.2.30"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz#2f1cc5b46bd76723be41d0013a8450c9ba92b777"
-  integrity sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==
-
-"@fortawesome/fontawesome-svg-core@^1.2.13":
-  version "1.2.30"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz#f56dc6791861fe5d1af04fb8abddb94658c576db"
-  integrity sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.30"
-
-"@fortawesome/free-solid-svg-icons@^5.7.0":
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz#970453f5e8c4915ad57856c3a0252ac63f6fec18"
-  integrity sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.30"
-
-"@fortawesome/react-fontawesome@^0.1.4":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz#c1a95a2bdb6a18fa97b355a563832e248bf6ef4a"
-  integrity sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==
-  dependencies:
-    prop-types "^15.7.2"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -6368,17 +6342,6 @@ react-popper@^2.2.5:
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==
   dependencies:
     react-fast-compare "^3.0.1"
-    warning "^4.0.2"
-
-react-responsive-pinch-zoom-pan@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-responsive-pinch-zoom-pan/-/react-responsive-pinch-zoom-pan-0.3.0.tgz#5a4412d2c4b36dc4ababdcc73f03f59f28b51d49"
-  integrity sha512-I+BJh0M+lfya6iCeKt8Adv87H/NQbSxCW0UU1vq66QNX98vMOhoGd6+TAOhjWaac9X1+sqiqUsIx0TnPzrxq8Q==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.13"
-    "@fortawesome/free-solid-svg-icons" "^5.7.0"
-    "@fortawesome/react-fontawesome" "^0.1.4"
-    reselect "^4.0.0"
     warning "^4.0.2"
 
 react-window@^1.8.6:


### PR DESCRIPTION
Copy pasted the source code of `react-responsive-pinch-zoom-pan` and made some changes:
- [x] no flicker/fade when switching to next/previous image 
- [x] keep same scroll position when coming back to gallery (unless you moved to an image out of view), fixes https://github.com/allusion-app/Allusion/issues/297
- [x] show thumbnail in slide mode until full res image is loaded: more responsive
- [x] smooooth transition from main gallery to slide mode
- [x] and even a transition back to gallery now! Also works decent w/ inspector open

https://user-images.githubusercontent.com/5946427/122656030-89d91f80-d157-11eb-8163-6bf8c4203c01.mp4

