### PR TITLE
Update titlebar with filename in slide mode

### DIFF
--- a/resources/style/remake/window-titlebar.scss
+++ b/resources/style/remake/window-titlebar.scss
@@ -9,7 +9,7 @@
 
   border-bottom: 0.0625rem solid var(--border-color);
 
-  span {
+  > span {
     height: 100%;
     display: inline-flex;
     align-items: center;
@@ -17,15 +17,25 @@
     flex-grow: 1;
     transition: margin 0.2s ease-in-out;
 
+    > span {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      min-width: 0;    
+    }
+
     // Center the text
     // Style for Windows+Linux: overwritten in block below for data-os='darwin':
 
     // same width as the 3 system buttons on the right, so text is centered
     margin-left: 108px;
+    max-width: calc(100% - 2 * 108px);
 
     // But not for a narrow window, it would overlap with buttons, so position it off-center
     @media only screen and (max-width: 320px) {
       margin-left: 0;
+      max-width: calc(100% - 108px);
+      padding-left: 4px;
     }
   }
 }
@@ -33,13 +43,14 @@
 // Conditional based on OS:
 [data-os='darwin'] {
   #window-titlebar {
-    span {
+    > span {
       // Opposite on OSX: buttons are on the left, but don't take up space in CSS: it's overlaid by the OS
-      margin-left: 0px;
+      margin-left: 108px;
+      max-width: calc(100% - 2 * 108px);
 
       // So, only make it off-center when the window is narrow
       @media only screen and (max-width: 320px) {
-        margin-left: 108px;
+        max-width: calc(100% - 108px);
       }
     }
   }

--- a/src/frontend/containers/ContentView/SlideMode/index.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/index.tsx
@@ -83,15 +83,18 @@ const SlideView = observer((props: SlideViewProps) => {
     [uiStore, fileStore.fileList.length],
   );
 
-  // Detect left/right arrow keys to scroll between images
+  // Detect left/right arrow keys to scroll between images. Top/down is already handled in the layout that's open in the background
   useEffect(() => {
     const handleUserKeyPress = (event: KeyboardEvent) => {
       if (event.key === 'ArrowLeft') {
         decrImgIndex();
+        event.stopPropagation();
       } else if (event.key === 'ArrowRight') {
         incrImgIndex();
+        event.stopPropagation();
       } else if (event.key === 'Escape' || event.key === 'Backspace') {
         uiStore.disableSlideMode();
+        event.stopPropagation();
       }
     };
     window.addEventListener('keydown', handleUserKeyPress);

--- a/src/frontend/containers/WindowTitlebar.tsx
+++ b/src/frontend/containers/WindowTitlebar.tsx
@@ -1,20 +1,26 @@
+import { observer } from 'mobx-react-lite';
 import React, { useEffect, useState } from 'react';
 import { RendererMessenger, WindowSystemButtonPress } from 'src/Messaging';
 import { IconSet } from 'widgets/Icons';
+import { useStore } from '../contexts/StoreContext';
 
 const PLATFORM = process.platform;
 
-const WindowsTitlebar = () => {
+const WindowsTitlebar = observer(() => {
+  const { uiStore } = useStore();
   return (
     <div id="window-titlebar">
       <div id="window-resize-area" />
 
-      <span>Allusion</span>
+      {/* Extra span needed for ellipsis; isn't compatible with display: flex */}
+      <span>
+        <span>{uiStore.windowTitle}</span>
+      </span>
 
       {PLATFORM !== 'darwin' && <WindowSystemButtons />}
     </div>
   );
-};
+});
 
 export default WindowsTitlebar;
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -116,6 +116,8 @@ class UiStore {
   // Theme
   @observable theme: 'light' | 'dark' = 'dark';
 
+  @observable windowTitle = 'Allusion';
+
   // UI
   @observable isOutlinerOpen: boolean = true;
   @observable isInspectorOpen: boolean = true;
@@ -215,9 +217,25 @@ class UiStore {
     this.setThumbnailShape('letterbox');
   }
 
+  @action updateWindowTitle() {
+    if (this.isSlideMode) {
+      const activeFile = this.rootStore.fileStore.fileList[this.firstItem];
+      this.windowTitle = `${activeFile.filename}.${activeFile.extension} - Allusion`;
+    } else {
+      this.windowTitle = 'Allusion';
+    }
+  }
+
   @action.bound setFirstItem(index: number = 0) {
-    if (isFinite(index)) {
+    console.log(
+      'setFirstItem',
+      index,
+      isFinite(index),
+      index < this.rootStore.fileStore.fileList.length,
+    );
+    if (isFinite(index) && index < this.rootStore.fileStore.fileList.length) {
       this.firstItem = index;
+      this.updateWindowTitle();
     }
   }
 
@@ -247,6 +265,7 @@ class UiStore {
 
   @action.bound disableSlideMode() {
     this.isSlideMode = false;
+    this.updateWindowTitle();
   }
 
   @action.bound toggleSlideMode() {

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -110,6 +110,11 @@ if (IS_PREVIEW_WINDOW) {
   } catch (e) {
     console.error('Cannot load window preferences', e);
   }
+
+  // Change window title to filename when changing the selected file
+  observe(rootStore.uiStore, 'windowTitle', ({ object }) => {
+    document.title = object.get();
+  });
 }
 
 window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
I noticed that the window title resets to `index.html` now when leaving slide mode ( (Electron 15 related?). Fixed that and thought it would be nice for the titlebar to include the current filename:

![image](https://user-images.githubusercontent.com/5946427/140232665-a57e1b14-d0fd-4986-b588-8435d75c1401.png)

The new Electron version is running smoothly btw! It doesn't crash anymore when restarting with Ctrl+R, used to happen frequently :pray: 
