### PR TITLE
Recreate thumbnails and update properties when files change on disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "style-loader": "^2.0.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.1.0",
-    "typescript": "^4.2.3",
+    "typescript": "^4.4.4",
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"
   },

--- a/src/backend/Backend.test.ts
+++ b/src/backend/Backend.test.ts
@@ -28,6 +28,7 @@ const mockFile: IFile = {
   dateAdded: new Date(),
   dateModified: new Date(),
   dateCreated: new Date(),
+  dateLastIndexed: new Date(),
   extension: 'jpg',
   id: '1234',
   tags: [mockTag.id],

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -1,4 +1,5 @@
 import { Transaction } from 'dexie';
+import { IFile } from 'src/entities/File';
 import { IDBVersioningConfig } from './DBRepository';
 
 // The name of the IndexedDB
@@ -42,6 +43,19 @@ export const dbConfig: IDBVersioningConfig[] = [
         .modify((location: any) => {
           location.subLocations = [];
           return location;
+        });
+    },
+  },
+  {
+    // Version 6, 13-11-21: Added lastIndexed date to File for recreating thumbnails
+    version: 6,
+    collections: [],
+    upgrade: async (tx: Transaction): Promise<void> => {
+      tx.table('files')
+        .toCollection()
+        .modify((file: IFile) => {
+          file.dateLastIndexed = file.dateAdded;
+          return file;
         });
     },
   },

--- a/src/entities/Location.ts
+++ b/src/entities/Location.ts
@@ -3,7 +3,7 @@ import fse from 'fs-extra';
 import { action, makeObservable, observable, runInAction } from 'mobx';
 import SysPath from 'path';
 import { AppToaster } from 'src/frontend/components/Toaster';
-import LocationStore from 'src/frontend/stores/LocationStore';
+import LocationStore, { FileStats } from 'src/frontend/stores/LocationStore';
 import { FolderWatcherWorker } from 'src/frontend/workers/folderWatcher.worker';
 import { RendererMessenger } from 'src/Messaging';
 import { ID, IResource, ISerializable } from './ID';
@@ -121,7 +121,7 @@ export class ClientLocation implements ISerializable<ILocation> {
     return SysPath.basename(this.path);
   }
 
-  @action async init(): Promise<string[] | undefined> {
+  @action async init(): Promise<FileStats[] | undefined> {
     const pathExists = await fse.pathExists(this.path);
     await this.refreshSublocations();
     runInAction(() => (this.isInitialized = true));
@@ -253,24 +253,31 @@ export class ClientLocation implements ISerializable<ILocation> {
     this.store.save(this.serialize());
   }
 
-  private async watch(directory: string): Promise<string[]> {
+  private async watch(directory: string): Promise<FileStats[]> {
     console.debug('Loading folder watcher worker...', directory);
     const worker = new Worker(
       new URL('src/frontend/workers/folderWatcher.worker', import.meta.url),
     );
-    worker.onmessage = ({ data: { type, value } }: { data: { type: string; value: string } }) => {
-      if (type === 'add') {
+    worker.onmessage = ({
+      data,
+    }: {
+      data: { type: 'remove' | 'error'; value: string } | { type: 'add'; value: FileStats };
+    }) => {
+      if (data.type === 'add') {
+        const { absolutePath } = data.value;
         // Filter out files located in any excluded subLocations
-        if (this.excludedPaths.some((subLoc) => value.startsWith(subLoc.path))) {
-          console.debug('File added to excluded sublocation', value);
+        if (this.excludedPaths.some((subLoc) => data.value.absolutePath.startsWith(subLoc.path))) {
+          console.debug('File added to excluded sublocation', absolutePath);
         } else {
-          console.log(`File ${value} has been added after initialization`);
-          this.store.addFile(value, this);
+          console.log(`File ${absolutePath} has been added after initialization`);
+          this.store.addFile(data.value, this);
         }
-      } else if (type === 'remove') {
+      } else if (data.type === 'remove') {
+        const { value } = data;
         console.log(`Location "${this.name}": File ${value} has been removed.`);
         this.store.hideFile(value);
-      } else if (type === 'error') {
+      } else if (data.type === 'error') {
+        const { value } = data;
         console.error('Location watch error:', value);
         AppToaster.show(
           {
@@ -292,7 +299,8 @@ export class ClientLocation implements ISerializable<ILocation> {
     // Filter out images from excluded sub-locations
     // TODO: Could also put them in the chokidar ignore property
     return initialFiles.filter(
-      (path) => !this.excludedPaths.some((subLoc) => path.startsWith(subLoc.path)),
+      ({ absolutePath }) =>
+        !this.excludedPaths.some((subLoc) => absolutePath.startsWith(subLoc.path)),
     );
   }
 }

--- a/src/frontend/containers/Outliner/LocationsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/LocationsPanel/index.tsx
@@ -330,7 +330,7 @@ const SubLocation = observer((props: { nodeData: ClientSubLocation; treeData: IT
   const existingSearchCrit = uiStore.searchCriteriaList.find(
     (c: any) => c.value === pathAsSearchPath(nodeData.path),
   );
-  const isSearched = Boolean(existingSearchCrit);
+  // const isSearched = Boolean(existingSearchCrit);
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
@@ -400,7 +400,7 @@ const Location = observer(
     const existingSearchCrit = uiStore.searchCriteriaList.find(
       (c: any) => c.value === pathAsSearchPath(nodeData.path),
     );
-    const isSearched = Boolean(existingSearchCrit);
+    // const isSearched = Boolean(existingSearchCrit);
 
     const handleClick = useCallback(
       (event: React.MouseEvent<HTMLElement, MouseEvent>) => {

--- a/src/frontend/stores/LocationStore.ts
+++ b/src/frontend/stores/LocationStore.ts
@@ -8,8 +8,9 @@ import { ClientLocation, ClientSubLocation, ILocation } from 'src/entities/Locat
 import { ClientStringSearchCriteria } from 'src/entities/SearchCriteria';
 import { AppToaster } from 'src/frontend/components/Toaster';
 import { RendererMessenger } from 'src/Messaging';
-import { promiseAllLimit } from '../utils';
+import { getThumbnailPath, promiseAllLimit } from '../utils';
 import RootStore from './RootStore';
+import fse from 'fs-extra';
 
 /**
  * Compares metadata of two files to determine whether the files are (likely to be) identical
@@ -104,14 +105,17 @@ class LocationStore {
         );
       }, 10000);
 
+      // TODO: get stats from chokidar too: no need to fse.stat(). Then check whether file has been modified and needs a new thumbnail
       console.debug('Location init...');
-      const filePaths = await location.init();
-      const filePathsSet = new Set(filePaths);
+      const diskFiles = await location.init();
+      const diskFileMap = new Map<string, FileStats>(
+        diskFiles?.map((f) => [f.absolutePath, f]) ?? [],
+      );
 
       clearTimeout(readyTimeout);
       AppToaster.dismiss('retry-init');
 
-      if (filePaths === undefined) {
+      if (diskFiles === undefined) {
         AppToaster.show(
           {
             message: `Cannot find Location "${location.name}"`,
@@ -124,14 +128,14 @@ class LocationStore {
 
       console.log('Finding created files...');
       // Find all files that have been created (those on disk but not in DB)
-      const createdPaths = filePaths.filter((path) => !dbFilesPathSet.has(path));
+      const createdPaths = diskFiles.filter((f) => !dbFilesPathSet.has(f.absolutePath));
       const createdFiles = await Promise.all(
         createdPaths.map((path) => pathToIFile(path, location)),
       );
 
       // Find all files of this location that have been removed (those in DB but not on disk anymore)
       const missingFiles = dbFiles.filter(
-        (file) => file.locationId === location.id && !filePathsSet.has(file.absolutePath),
+        (file) => file.locationId === location.id && !diskFileMap.has(file.absolutePath),
       );
 
       // Find matches between removed and created images (different name/path but same characteristics)
@@ -221,8 +225,38 @@ class LocationStore {
         await this.backend.createFilesFromPath(location.path, newFiles);
       }
 
-      // TODO: Also update files that have changed, e.g. when overwriting a file (with same filename)
-      // Look at modified date? Or file size? For these ones, update metadata (resolution, size) and recreate thumbnail
+      // Also update files that have changed, e.g. when overwriting a file (with same filename)
+      // --> update metadata (resolution, size) and recreate thumbnail
+      // This can be accomplished by comparing the dateLastIndexed of the file in DB to dateModified of the file on disk
+      const updatedFiles: IFile[] = [];
+      for (const dbFile of dbFiles) {
+        const diskFile = diskFileMap.get(dbFile.absolutePath);
+        if (diskFile && dbFile.dateLastIndexed.getTime() < diskFile.dateModified.getTime()) {
+          console.debug('Re-indexing file', dbFile.absolutePath);
+          let newFile = {
+            ...dbFile,
+            size: diskFile.size,
+            dateModified: diskFile.dateModified,
+            dateLastIndexed: new Date(),
+          };
+          if (diskFile.size !== dbFile.size) {
+            // Delete thumbnail if size has changed, will be re-created automatically when needed
+            const thumbPath = getThumbnailPath(
+              dbFile.absolutePath,
+              this.rootStore.uiStore.thumbnailDirectory,
+            );
+            fse.remove(thumbPath).catch(console.error);
+
+            // Recreate metadata which checks the resolution of the image
+            const meta = await getMetaData(diskFile);
+            newFile = { ...newFile, ...meta };
+          }
+
+          updatedFiles.push(newFile);
+        }
+      }
+      await this.backend.saveFiles(updatedFiles);
+
       foundNewFiles = foundNewFiles || newFiles.length > 0;
     }
 
@@ -357,9 +391,9 @@ class LocationStore {
     this.rootStore.fileStore.refetchFileCounts();
   }
 
-  @action async addFile(path: string, location: ClientLocation) {
-    const file = await pathToIFile(path, location);
-    await this.backend.createFilesFromPath(path, [file]);
+  @action async addFile(fileStats: FileStats, location: ClientLocation) {
+    const file = await pathToIFile(fileStats, location);
+    await this.backend.createFilesFromPath(fileStats.absolutePath, [file]);
 
     AppToaster.show({ message: 'New images have been detected.', timeout: 5000 }, 'new-images');
     // might be called a lot when moving many images into a folder, so debounce it
@@ -409,16 +443,28 @@ class LocationStore {
   }
 }
 
-async function pathToIFile(path: string, loc: ClientLocation): Promise<IFile> {
+export type FileStats = {
+  absolutePath: string;
+  /** When file was last modified on disk */
+  dateModified: Date;
+  /** When file was created on disk */
+  dateCreated: Date;
+  /** Current size of the file in bytes */
+  size: number;
+};
+
+async function pathToIFile(stats: FileStats, loc: ClientLocation): Promise<IFile> {
+  const now = new Date();
   return {
-    absolutePath: path,
-    relativePath: path.replace(loc.path, ''),
+    absolutePath: stats.absolutePath,
+    relativePath: stats.absolutePath.replace(loc.path, ''),
     id: generateId(),
     locationId: loc.id,
     tags: [],
-    dateAdded: new Date(),
-    dateModified: new Date(),
-    ...(await getMetaData(path)),
+    dateAdded: now,
+    dateModified: now,
+    dateLastIndexed: now,
+    ...(await getMetaData(stats)),
   };
 }
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -227,12 +227,6 @@ class UiStore {
   }
 
   @action.bound setFirstItem(index: number = 0) {
-    console.log(
-      'setFirstItem',
-      index,
-      isFinite(index),
-      index < this.rootStore.fileStore.fileList.length,
-    );
     if (isFinite(index) && index < this.rootStore.fileStore.fileList.length) {
       this.firstItem = index;
       this.updateWindowTitle();

--- a/src/frontend/workers/folderWatcher.worker.ts
+++ b/src/frontend/workers/folderWatcher.worker.ts
@@ -4,6 +4,7 @@ import { Stats } from 'fs';
 import SysPath from 'path';
 import { RECURSIVE_DIR_WATCH_DEPTH } from 'src/config';
 import { IMG_EXTENSIONS, IMG_EXTENSIONS_TYPE } from 'src/entities/File';
+import { FileStats } from '../stores/LocationStore';
 
 const ctx: Worker = self as any;
 
@@ -75,12 +76,12 @@ export class FolderWatcherWorker {
     const watcher = this.watcher;
 
     // Make a list of all files in this directory, which will be returned when all subdirs have been traversed
-    const initialFiles: string[] = [];
+    const initialFiles: FileStats[] = [];
 
-    return new Promise<string[]>((resolve) => {
+    return new Promise<FileStats[]>((resolve) => {
       watcher
-        .on('add', async (path) => {
-          // TODO: We already get file stats here as second arg, no need to get those later for importing in DB
+        // we can assume stats exist since we passed alwaysStat: true to chokidar
+        .on('add', async (path, stats: Stats) => {
           if (this.isCancelled) {
             console.log('Cancelling file watching');
             await watcher.close();
@@ -92,7 +93,12 @@ export class FolderWatcherWorker {
             if (this.isReady) {
               ctx.postMessage({ type: 'add', value: path });
             } else {
-              initialFiles.push(path);
+              initialFiles.push({
+                absolutePath: path,
+                dateCreated: stats?.birthtime,
+                dateModified: stats?.mtime,
+                size: stats?.size,
+              });
             }
           }
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -533,13 +533,26 @@ MainMessenger.onDragExport((absolutePaths) => {
     return;
   }
 
-  let previewIcon = nativeImage.createFromPath(absolutePaths[0]);
+  // TODO: should use the thumbnail used in the renderer process here, so formats not natively supported (e.g. webp) can be used as well
+  let previewIcon = nativeImage.createEmpty();
+  try {
+    previewIcon = nativeImage.createFromPath(absolutePaths[0]);
+  } catch (e) {
+    console.error('Could not create drag icon', absolutePaths[0], e);
+  }
+
   const isPreviewEmpty = previewIcon.isEmpty();
   if (!isPreviewEmpty) {
     // Resize preview to something resonable: taking into account aspect ratio
     const ratio = previewIcon.getAspectRatio();
-    previewIcon =
-      ratio > 1 ? previewIcon.resize({ width: 200 }) : previewIcon.resize({ height: 200 });
+    const size = previewIcon.getSize();
+    const targetThumbSize = 200;
+    if (size.width > targetThumbSize || size.height > targetThumbSize) {
+      previewIcon =
+        ratio > 1
+          ? previewIcon.resize({ width: targetThumbSize })
+          : previewIcon.resize({ height: targetThumbSize });
+    }
   }
 
   // Need to cast item as `any` since the types are not correct. The `files` field is allowed but

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "useDefineForClassFields": true,
+    "useUnknownInCatchVariables": false,
     "strict": true
   },
   "include": ["widgets/**/*", "src/**/*", "custom.d.ts", "types/*.d.ts", "wasm/**/*"],

--- a/widgets/menus/ContextMenu.tsx
+++ b/widgets/menus/ContextMenu.tsx
@@ -28,14 +28,14 @@ export interface IContextMenu {
  */
 export const ContextMenu = ({ isOpen, x, y, children, close, usePortal = true }: IContextMenu) => {
   const container = useRef<HTMLDivElement>(null);
-  const boundingRect = useRef({
-    width: 0,
-    height: 0,
-    top: y,
-    right: x,
-    bottom: y,
-    left: x,
-  });
+  const boundingRect = useRef<DOMRect>(
+    DOMRect.fromRect({
+      width: 0,
+      height: 0,
+      x,
+      y,
+    }),
+  );
   const [virtualElement, setVirtualElement] = useState({
     getBoundingClientRect: () => boundingRect.current,
   });
@@ -47,13 +47,14 @@ export const ContextMenu = ({ isOpen, x, y, children, close, usePortal = true }:
       container.current.focus();
 
       // Update bounding rect
-      const rect = boundingRect.current;
-      rect.top = y;
-      rect.right = x;
-      rect.bottom = y;
-      rect.left = x;
+      const rect = DOMRect.fromRect({
+        width: boundingRect.current.width,
+        height: boundingRect.current.height,
+        x,
+        y,
+      });
       setVirtualElement({
-        getBoundingClientRect: () => boundingRect.current,
+        getBoundingClientRect: () => rect,
       });
     }
   }, [isOpen, x, y]);

--- a/widgets/popovers/Alert.tsx
+++ b/widgets/popovers/Alert.tsx
@@ -37,7 +37,8 @@ export const Alert = (props: AlertProps) => {
 
   useEffect(() => {
     if (dialog.current) {
-      open ? dialog.current.showModal() : dialog.current.close();
+      const elemHack = dialog.current as any; // fixme: Updated TS doesn't support HTMLDialogElement anymore?
+      open ? elemHack.showModal?.() : elemHack.close?.();
     }
   }, [open]);
 

--- a/widgets/popovers/Dialog.tsx
+++ b/widgets/popovers/Dialog.tsx
@@ -42,7 +42,8 @@ export const Dialog = (props: DialogProps) => {
 
   useEffect(() => {
     if (dialog.current) {
-      open ? dialog.current.showModal() : dialog.current.close();
+      const elemHack = dialog.current as any; // fixme: Updated TS doesn't support HTMLDialogElement anymore?
+      open ? elemHack.showModal?.() : elemHack.close?.();
     }
   }, [open]);
 

--- a/widgets/popovers/Tooltip.tsx
+++ b/widgets/popovers/Tooltip.tsx
@@ -58,14 +58,15 @@ export const TooltipLayer = () => {
         const x = e.clientX;
         const y = e.clientY;
         virtualElement.current = {
-          getBoundingClientRect: () => ({
-            width: 4,
-            height: 4,
-            top: y,
-            right: x,
-            bottom: y,
-            left: x,
-          }),
+          getBoundingClientRect: () =>
+            ({
+              width: 4,
+              height: 4,
+              top: y,
+              right: x,
+              bottom: y,
+              left: x,
+            } as DOMRect),
           contextElement: target,
         };
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7560,10 +7560,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Added another block of code to the already far too long location initialization method, which runs on startup of Allusion.

It compares all files found on disk to those in DB, specifically the date when it was last indexed in Allusion and when it was last changed on disk, and updates the DB files accordingly and deletes thumbnails so they'll be recreated when needed.

I've optimized the fetching of file stats by getting it for free from Chokidar (which watches the Location folders) instead of reading it from disk manually, so I think the overall initialization performance should be about the same

Fixes #358 