### PR TITLE
RC6 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "allusion",
   "productName": "Allusion",
-  "version": "1.0.0-rc6",
+  "version": "1.0.0-rc6.1",
   "description": "A tool for managing your visual library",
   "main": "build/main.bundle.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "css-loader": "^5.2.0",
-    "electron": "15.0.0",
+    "electron": "^15.3.3",
     "electron-builder": "^22.10.5",
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^8.1.0",

--- a/resources/style/inspector.scss
+++ b/resources/style/inspector.scss
@@ -1,10 +1,23 @@
 ///////////////////////////////// Inspector /////////////////////////////////
 #inspector {
   background-color: var(--background-color);
-  overflow: hidden;
+  overflow: hidden auto; // show a Y scrollbar if inspector is too small in height to fit min-height of its content
+
+  display: flex;
+  flex-direction: column;
 
   > * {
     padding: 0.25rem 0.5rem;
+
+    // Tags section should shrink to fit its parent if the inspector is small in height
+    &:last-child {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      overflow: hidden;
+      // so that the tags section remains visible when inspector is very small in height: inspector should overflow with a scrollbar
+      min-height: 6rem;
+    }
   }
 
   header {

--- a/resources/style/remake/outliner.scss
+++ b/resources/style/remake/outliner.scss
@@ -97,9 +97,11 @@
 
 .tree-content-label {
   display: flex;
+  flex: 1 1 auto;
   align-items: center;
   height: 1.5rem;
   width: 100%;
+  overflow: hidden;
   white-space: nowrap;
 
   span {
@@ -148,10 +150,10 @@
   }
 
   > .label-text {
+    flex: 1;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: clip visible;
-    width: 100%;
     line-height: 1;
     padding-bottom: 0px;
   }

--- a/resources/style/remake/tag-editor.scss
+++ b/resources/style/remake/tag-editor.scss
@@ -15,14 +15,25 @@
   overflow: auto;
   resize: vertical;
 
+  // Intended layout behavior:
+  // - Input element has a static height
+  // - The tag checklist grows to fit the available space, until a max-height is reached
+  // - The applied tags section has a static height of 1.5 rows of tags,
+  //   and grows when the tag check-list has reached max-height
+  //   TODO: preferably: this section first fits to its content up to 3.5 rows (so only 1 row if there is 1 row of tags)
+  //   could figure out the CSS: we need something like min-height: calc(max(1.5rem, min(fit-content, 3.5rem)))
+  //   maybe with the fit-content() property coming soon? https://developer.mozilla.org/en-US/docs/Web/CSS/min-height#:~:text=5.0-,fit%2Dcontent(),-Experimental
+
   > input {
     margin: 0.5rem;
     width: auto;
     height: auto;
+    min-height: fit-content; // prevents weird slight resize when checklist shrinks when resizing parent
   }
 
+  // Checklist of all available tags
   [role='grid'] {
-    flex: 1;
+    flex: 0 1 calc(16rem + 1px); // expand to fill available space, don't shrink unless absolutaly necessary
     border-top: 0.0625rem solid var(--border-color);
     border-bottom: 0.0625rem solid var(--border-color);
     max-width: unset;
@@ -34,14 +45,17 @@
     }
   }
 
+  // The tags applied to the selected images
   > div:last-child {
+    flex: 1 1 auto; // shrink to make room for other elements, but grow if there is space available (other other elements reached their max height)
     margin: 0.5rem;
-    min-height: 1.375rem;
-    max-height: 3.5rem;
+    height: 3.375rem;
+    min-height: 2.375rem;
+    // preferably: min-height calc(max(min(3.75rem, fit-content), 1.375rem)), but doesn't work
     overflow: auto;
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-content: flex-start;
   }
 }
 

--- a/src/Messaging.ts
+++ b/src/Messaging.ts
@@ -32,6 +32,7 @@ const TOGGLE_DEV_TOOLS = 'TOGGLE_DEV_TOOLS';
 const RELOAD = 'RELOAD';
 const OPEN_DIALOG = 'OPEN_DIALOG';
 const GET_PATH = 'GET_PATH';
+const TRASH_FILE = 'TRASH_FILE';
 const SET_FULL_SCREEN = 'SET_FULL_SCREEN';
 const IS_FULL_SCREEN = 'IS_FULL_SCREEN';
 const FULL_SCREEN_CHANGED = 'FULL_SCREEN_CHANGED';
@@ -137,6 +138,9 @@ export class RendererMessenger {
 
   static getPath = (name: SYSTEM_PATHS): Promise<string> => ipcRenderer.invoke(GET_PATH, name);
 
+  static trashFile = (absolutePath: string): Promise<Error | undefined> =>
+    ipcRenderer.invoke(TRASH_FILE, absolutePath);
+
   static setFullScreen = (isFullScreen: boolean) =>
     ipcRenderer.invoke(SET_FULL_SCREEN, isFullScreen);
 
@@ -234,6 +238,15 @@ export class MainMessenger {
 
   static onGetPath = (cb: (name: SYSTEM_PATHS) => string) =>
     ipcMain.handle(GET_PATH, (_, name) => cb(name));
+
+  static onTrashFile = (cb: (absolutePath: string) => Promise<void>) =>
+    ipcMain.handle(TRASH_FILE, async (_, absolutePath) => {
+      try {
+        await cb(absolutePath);
+      } catch (e) {
+        return e;
+      }
+    });
 
   static onSetFullScreen = (cb: (isFullScreen: boolean) => void) =>
     ipcMain.handle(SET_FULL_SCREEN, (_, isFullScreen) => cb(isFullScreen));

--- a/src/frontend/components/TagSelector.tsx
+++ b/src/frontend/components/TagSelector.tsx
@@ -21,6 +21,8 @@ export interface TagSelectorProps {
     inputText: string,
     resetTextBox: () => void,
   ) => ReactElement<RowProps> | ReactElement<RowProps>[];
+  multiline?: boolean;
+  showTagContextMenu?: (e: React.MouseEvent<HTMLElement>, tag: ClientTag) => void;
 }
 
 const TagSelector = (props: TagSelectorProps) => {
@@ -29,10 +31,12 @@ const TagSelector = (props: TagSelectorProps) => {
     onSelect,
     onDeselect,
     onTagClick,
+    showTagContextMenu,
     onClear,
     disabled,
     extraIconButtons,
     renderCreateOption,
+    multiline,
   } = props;
   const gridId = useRef(generateWidgetId('__suggestions')).current;
   const inputRef = useRef<HTMLInputElement>(null);
@@ -86,6 +90,8 @@ const TagSelector = (props: TagSelectorProps) => {
 
   const handleFocus = useRef(() => setIsOpen(true)).current;
 
+  const handleBackgroundClick = useCallback(() => inputRef.current?.focus(), []);
+
   const resetTextBox = useRef(() => {
     inputRef.current?.focus();
     setQuery('');
@@ -109,8 +115,9 @@ const TagSelector = (props: TagSelectorProps) => {
       aria-expanded={isOpen}
       aria-haspopup="grid"
       aria-owns={gridId}
-      className="input multiautocomplete tag-selector"
+      className={`input multiautocomplete tag-selector ${multiline ? 'multiline' : ''}`}
       onBlur={handleBlur}
+      onClick={handleBackgroundClick}
     >
       <Flyout
         isOpen={isOpen}
@@ -121,7 +128,13 @@ const TagSelector = (props: TagSelectorProps) => {
           <div className="multiautocomplete-input">
             <div className="input-wrapper">
               {selection.map((t) => (
-                <SelectedTag key={t.id} tag={t} onDeselect={onDeselect} onTagClick={onTagClick} />
+                <SelectedTag
+                  key={t.id}
+                  tag={t}
+                  onDeselect={onDeselect}
+                  onTagClick={onTagClick}
+                  showContextMenu={showTagContextMenu}
+                />
               ))}
               <input
                 disabled={disabled}
@@ -161,16 +174,18 @@ interface SelectedTagProps {
   tag: ClientTag;
   onDeselect: (item: ClientTag) => void;
   onTagClick?: (item: ClientTag) => void;
+  showContextMenu?: (e: React.MouseEvent<HTMLElement>, item: ClientTag) => void;
 }
 
 const SelectedTag = observer((props: SelectedTagProps) => {
-  const { tag, onDeselect, onTagClick } = props;
+  const { tag, onDeselect, onTagClick, showContextMenu } = props;
   return (
     <Tag
       text={tag.name}
       color={tag.viewColor}
       onRemove={() => onDeselect(tag)}
       onClick={onTagClick !== undefined ? () => onTagClick(tag) : undefined}
+      onContextMenu={showContextMenu !== undefined ? (e) => showContextMenu(e, tag) : undefined}
     />
   );
 });

--- a/src/frontend/containers/AppToolbar/FileTagEditor.tsx
+++ b/src/frontend/containers/AppToolbar/FileTagEditor.tsx
@@ -112,9 +112,21 @@ const TagEditor = () => {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      // Prevent backspace from navigating back to main view when having an image open
       if (e.key === 'Backspace') {
+        // Prevent backspace from navigating back to main view when having an image open
         e.stopPropagation();
+      }
+
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        // If shift key is pressed with arrow keys left/right,
+        // stop those key events from propagating to the gallery,
+        // so that the cursor in the text input can be moved without selecting the prev/next image
+        // Kind of an ugly work-around, but better than not being able to move the cursor at all
+        if (e.shiftKey) {
+          e.stopPropagation(); // move text cursor as expected (and select text because shift is pressed)
+        } else {
+          e.preventDefault(); // don't do anything here: let the event propagate to the gallery
+        }
       }
       handleGridFocus(e);
     },
@@ -290,7 +302,7 @@ const FloatingPanel = observer(({ children }: { children: ReactNode }) => {
     }
   }).current;
 
-  const handleClose = useRef((e: React.KeyboardEvent) => {
+  const handleKeyDown = useRef((e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.stopPropagation();
       uiStore.closeToolbarTagPopover();
@@ -305,7 +317,7 @@ const FloatingPanel = observer(({ children }: { children: ReactNode }) => {
       data-open={uiStore.isToolbarTagPopoverOpen}
       className="floating-dialog"
       onBlur={handleBlur}
-      onKeyDown={handleClose}
+      onKeyDown={handleKeyDown}
     >
       {uiStore.isToolbarTagPopoverOpen ? children : null}
     </div>

--- a/src/frontend/containers/AppToolbar/FileTagEditor.tsx
+++ b/src/frontend/containers/AppToolbar/FileTagEditor.tsx
@@ -110,6 +110,17 @@ const TagEditor = () => {
     inputRef.current?.focus();
   });
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Prevent backspace from navigating back to main view when having an image open
+      if (e.key === 'Backspace') {
+        e.stopPropagation();
+      }
+      handleGridFocus(e);
+    },
+    [handleGridFocus],
+  );
+
   return (
     <div
       ref={panelRef}
@@ -126,7 +137,7 @@ const TagEditor = () => {
         value={inputText}
         aria-autocomplete="list"
         onChange={handleInput}
-        onKeyDown={handleGridFocus}
+        onKeyDown={handleKeyDown}
         className="input"
         aria-controls={POPUP_ID}
         aria-activedescendant={activeDescendant}

--- a/src/frontend/containers/ContentView/LayoutSwitcher.tsx
+++ b/src/frontend/containers/ContentView/LayoutSwitcher.tsx
@@ -89,12 +89,13 @@ const Layout = ({ contentRect, showContextMenu }: LayoutProps) => {
       }
       if (e.key === 'ArrowLeft' && index > 0) {
         index -= 1;
-        // TODO: when the activeElement GalleryItem goes out of view, focus will be handed over to the body element:
-        // -> Gallery keyboard shortkeys stop working. So, force focus on container
-        FocusManager.focusGallery();
+        // When the activeElement GalleryItem goes out of view, focus will be handed over to the body element:
+        // -> Gallery keyboard shortkeys stop working. So, force focus on Gallery container instead
+        // But not when the TagEditor overlay is open: it will close onBlur
+        if (!uiStore.isToolbarTagPopoverOpen) FocusManager.focusGallery();
       } else if (e.key === 'ArrowRight' && index < fileStore.fileList.length - 1) {
         index += 1;
-        FocusManager.focusGallery();
+        if (!uiStore.isToolbarTagPopoverOpen) FocusManager.focusGallery();
       } else {
         return;
       }

--- a/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
+++ b/src/frontend/containers/ContentView/Masonry/MasonryRenderer.tsx
@@ -75,13 +75,18 @@ const MasonryRenderer = observer(({ contentRect, select, lastSelectionIndex }: G
       }
       e.preventDefault();
       select(fileStore.fileList[index], e.ctrlKey || e.metaKey, e.shiftKey);
-      FocusManager.focusGallery();
+
+      // Don't change focus when TagEditor overlay is open: is closes onBlur
+      if (!uiStore.isToolbarTagPopoverOpen) {
+        FocusManager.focusGallery();
+      }
     });
 
     const throttledKeyDown = throttle(onKeyDown, 50);
     window.addEventListener('keydown', throttledKeyDown);
     return () => window.removeEventListener('keydown', throttledKeyDown);
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Initialize on mount
   useEffect(() => {

--- a/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
@@ -72,6 +72,8 @@ const Label = (props: ILabelProps) =>
         }
       }}
       onFocus={(e) => e.target.select()}
+      // Stop propagation so that the parent Tag element doesn't toggle selection status
+      onClick={(e) => e.stopPropagation()}
       // TODO: Visualizing errors...
       // Only show red outline when input field is in focus and text is invalid
     />

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -60,7 +60,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   openTagEditor: 't',
   selectAll: 'mod + a',
   deselectAll: 'mod + d',
-  viewSlide: 'alt + 0',
+  viewSlide: 'enter', // TODO: backspace and escape are hardcoded hotkeys to exist slide mode
   viewList: 'alt + 1',
   viewGrid: 'alt + 2',
   viewMasonryVertical: 'alt + 3',

--- a/src/main.ts
+++ b/src/main.ts
@@ -520,11 +520,26 @@ autoUpdater.on('update-not-available', () => {
 });
 
 autoUpdater.on('update-downloaded', async () => {
+  if (mainWindow !== null && !mainWindow.isDestroyed()) {
+    mainWindow.setProgressBar(10); // indeterminate mode until application is restarted
+  }
   await dialog.showMessageBox({
     title: 'Install Updates',
     message: 'Updates downloaded, Allusion will restart...',
   });
   setImmediate(() => autoUpdater.quitAndInstall());
+});
+
+// Show the auto-update download progress in the task bar
+autoUpdater.on('download-progress', (progressObj: { percent: number }) => {
+  if (mainWindow === null || mainWindow.isDestroyed()) {
+    return;
+  }
+  if (tray && !tray.isDestroyed()) {
+    tray.setToolTip(`Allusion - Downloading update ${progressObj.percent.toFixed(0)}%`);
+  }
+  // TODO: could also do this for other tasks (e.g. importing folders)
+  mainWindow.setProgressBar(progressObj.percent / 100);
 });
 
 //---------------------------------------------------------------------------------//

--- a/src/main.ts
+++ b/src/main.ts
@@ -643,6 +643,8 @@ MainMessenger.onOpenDialog(dialog);
 
 MainMessenger.onGetPath((path) => app.getPath(path));
 
+MainMessenger.onTrashFile((absolutePath) => shell.trashItem(absolutePath));
+
 MainMessenger.onIsFullScreen(() => mainWindow?.isFullScreen() ?? false);
 
 MainMessenger.onSetFullScreen((isFullScreen) => mainWindow?.setFullScreen(isFullScreen));

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -120,9 +120,6 @@ if (IS_PREVIEW_WINDOW) {
   observe(rootStore.uiStore, 'windowTitle', ({ object }) => {
     document.title = object.get();
   });
-
-  // Dim the titlebar when the window is unfocused
-  
 }
 
 window.addEventListener('beforeunload', () => {
@@ -153,7 +150,9 @@ ReactDOM.render(
  */
 async function addTagsToFile(filePath: string, tagNames: string[]) {
   const { fileStore, tagStore } = rootStore;
-  const clientFile = fileStore.fileList.find((file) => file.absolutePath === filePath);
+  const clientFile = runInAction(() =>
+    fileStore.fileList.find((file) => file.absolutePath === filePath),
+  );
   if (clientFile) {
     const tags = await Promise.all(
       tagNames.map(async (tagName) => {

--- a/widgets/Combobox/input.scss
+++ b/widgets/Combobox/input.scss
@@ -7,6 +7,7 @@
     display: flex;
     flex-grow: 1;
     flex-wrap: wrap;
+    overflow-x: hidden; // prevent tags with really long names from extending the width of the input
   }
 
   input {
@@ -45,6 +46,11 @@
   &.multiautocomplete {
     max-height: 1.75rem;
     overflow: hidden auto;
+  }
+
+  &.multiline {
+    height: unset;
+    max-height: 100vh;
   }
 }
 

--- a/widgets/Tree/tree.scss
+++ b/widgets/Tree/tree.scss
@@ -38,10 +38,10 @@
       transition: background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     }
     .spacer {
+      flex: 1 0 auto;
       height: 1rem;
       width: 1rem;
       margin-right: 0.25rem;
-      flex-shrink: 0;
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,10 +3303,10 @@ electron-updater@^4.3.8:
     lodash.isequal "^4.5.0"
     semver "^7.3.4"
 
-electron@15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-15.0.0.tgz#b1b6244b1cffddf348c27c54b1310b3a3680246e"
-  integrity sha512-LlBjN5nCJoC7EDrgfDQwEGSGSAo/o08nSP5uJxN2m+ZtNA69SxpnWv4yPgo1K08X/iQPoGhoZu6C8LYYlk1Dtg==
+electron@^15.3.3:
+  version "15.3.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-15.3.3.tgz#e66c6c6fbcd74641dbfafe5e101228d2b7734c7b"
+  integrity sha512-tr4UaMosN6+s8vSbx6OxqRXDTTCBjjJkmDMv0b0sg8f+cRFQeY0u7xYbULpXS4B1+hHJmdh7Nz40Qpv0bJXa6w==
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
- [x] Overflow issues in tag editor overlay and the one in the inspector https://github.com/allusion-app/Allusion/issues/382
- [x] Prevent backspace in tag editor overlay input field from navigating back to the main view when having an image open https://github.com/allusion-app/Allusion/issues/385
- [x] Browser extension issue: imported images being immediately shown https://github.com/allusion-app/Allusion/issues/386
- [x] The tag editor overlay should show tags for the current image after navigating left/right with a single image open
- [x] Magnifying glass icons in outliner shift to the right for tags with long names
- [x] Fix for weird behavior when clicking tag rename input  #388
- [x] Fix for deleting files: Didn't work anymore since upgrading to a newer Electron version (internal breaking changes)
- [x] Bonus: Task bar entry will show a progress bar when downloading an update
- [x] Tweaked behavior for left/right arrow keys in gallery when the TagEditor overlay is open. I tried to find a solution that keeps the best of both worlds:
  - It now no longer closes when moving between images, nor is the cursor in the input field moved
  - To still have control over input field text, holding Shift will move the text cursor, but the event no longer selects files in the gallery
  