### PR TITLE
Remember search on startup

### DIFF
--- a/src/entities/ID.ts
+++ b/src/entities/ID.ts
@@ -13,8 +13,8 @@ export interface IResource {
 }
 
 /** Converting client objects into database objects */
-export interface ISerializable<S> {
-  serialize(): S;
+export interface ISerializable<S, P = unknown> {
+  serialize(arg: P): S;
 }
 
 export function generateId(): ID {

--- a/src/frontend/containers/AdvancedSearch/data.ts
+++ b/src/frontend/containers/AdvancedSearch/data.ts
@@ -9,7 +9,6 @@ import {
 } from 'src/entities/SearchCriteria';
 import { FileSearchCriteria } from 'src/frontend/stores/UiStore';
 import {
-  CustomKeyDict,
   ClientStringSearchCriteria,
   ClientTagSearchCriteria,
   ClientDateSearchCriteria,
@@ -79,7 +78,7 @@ export function fromCriteria(criteria: FileSearchCriteria): [ID, Criteria] {
   } else if (criteria instanceof ClientNumberSearchCriteria && criteria.key === 'size') {
     query.value = criteria.value / BYTES_IN_MB;
   } else if (criteria instanceof ClientTagSearchCriteria && criteria.key === 'tags') {
-    const id = criteria.value.length > 0 ? criteria.value[0] : undefined;
+    const id = criteria.value;
     query.value = id;
   } else {
     return [generateCriteriaId(), query];
@@ -91,31 +90,19 @@ export function fromCriteria(criteria: FileSearchCriteria): [ID, Criteria] {
 
 export function intoCriteria(query: Criteria, tagStore: TagStore): FileSearchCriteria {
   if (query.key === 'name' || query.key === 'absolutePath' || query.key === 'extension') {
-    return new ClientStringSearchCriteria(query.key, query.value, query.operator, CustomKeyDict);
+    return new ClientStringSearchCriteria(query.key, query.value, query.operator);
   } else if (query.key === 'dateAdded') {
-    return new ClientDateSearchCriteria(query.key, query.value, query.operator, CustomKeyDict);
+    return new ClientDateSearchCriteria(query.key, query.value, query.operator);
   } else if (query.key === 'size') {
-    return new ClientNumberSearchCriteria(
-      query.key,
-      query.value * BYTES_IN_MB,
-      query.operator,
-      CustomKeyDict,
-    );
+    return new ClientNumberSearchCriteria(query.key, query.value * BYTES_IN_MB, query.operator);
   } else if (query.key === 'tags') {
     const tag = query.value !== undefined ? tagStore.get(query.value) : undefined;
     if (tag !== undefined) {
-      return new ClientTagSearchCriteria(
-        tagStore,
-        query.key,
-        tag.id,
-        tag.name,
-        query.operator,
-        CustomKeyDict,
-      );
+      return new ClientTagSearchCriteria('tags', tag.id, query.operator);
     } else {
-      return new ClientTagSearchCriteria(tagStore, 'tags');
+      return new ClientTagSearchCriteria('tags');
     }
   } else {
-    return new ClientTagSearchCriteria(tagStore, 'tags');
+    return new ClientTagSearchCriteria('tags');
   }
 }

--- a/src/frontend/containers/Outliner/LocationsPanel/index.tsx
+++ b/src/frontend/containers/Outliner/LocationsPanel/index.tsx
@@ -5,7 +5,7 @@ import SysPath from 'path';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { IFile } from 'src/entities/File';
 import { ClientLocation, ClientSubLocation } from 'src/entities/Location';
-import { ClientStringSearchCriteria, CustomKeyDict } from 'src/entities/SearchCriteria';
+import { ClientStringSearchCriteria } from 'src/entities/SearchCriteria';
 import { Collapse } from 'src/frontend/components/Collapse';
 import { LocationRemoval, SubLocationExclusion } from 'src/frontend/components/RemovalAlert';
 import { AppToaster } from 'src/frontend/components/Toaster';
@@ -112,12 +112,7 @@ const triggerContextMenuEvent = (event: React.KeyboardEvent<HTMLLIElement>) => {
 const pathAsSearchPath = (path: string) => `${path}${SysPath.sep}`;
 
 const pathCriteria = (path: string) =>
-  new ClientStringSearchCriteria<IFile>(
-    'absolutePath',
-    pathAsSearchPath(path),
-    'startsWith',
-    CustomKeyDict,
-  );
+  new ClientStringSearchCriteria<IFile>('absolutePath', pathAsSearchPath(path), 'startsWith');
 
 const customKeys = (
   search: (path: string) => void,

--- a/src/frontend/containers/Outliner/TagsPanel/ContextMenu.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/ContextMenu.tsx
@@ -127,7 +127,7 @@ export const TagItemContextMenu = observer((props: IContextMenuProps) => {
         onClick={() =>
           tag.isSelected
             ? uiStore.addTagSelectionToCriteria()
-            : uiStore.addSearchCriteria(new ClientTagSearchCriteria(tagStore, 'tags', tag.id))
+            : uiStore.addSearchCriteria(new ClientTagSearchCriteria('tags', tag.id))
         }
         text="Add to Search"
         icon={IconSet.SEARCH}
@@ -136,7 +136,7 @@ export const TagItemContextMenu = observer((props: IContextMenuProps) => {
         onClick={() =>
           tag.isSelected
             ? uiStore.replaceCriteriaWithTagSelection()
-            : uiStore.replaceSearchCriteria(new ClientTagSearchCriteria(tagStore, 'tags', tag.id))
+            : uiStore.replaceSearchCriteria(new ClientTagSearchCriteria('tags', tag.id))
         }
         text="Replace Search"
         icon={IconSet.REPLACE}

--- a/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
+++ b/src/frontend/containers/Outliner/TagsPanel/TagsTree.tsx
@@ -101,7 +101,7 @@ interface ITagItemProps {
  * query. Handling filter mode or replacing the search criteria list is up to
  * the component.
  */
-const toggleQuery = (nodeData: ClientTag, uiStore: UiStore, tagStore: TagStore) => {
+const toggleQuery = (nodeData: ClientTag, uiStore: UiStore) => {
   if (nodeData.isSearched) {
     // if it already exists, then remove it
     const alreadySearchedCrit = uiStore.searchCriteriaList.find((c) =>
@@ -113,7 +113,7 @@ const toggleQuery = (nodeData: ClientTag, uiStore: UiStore, tagStore: TagStore) 
       );
     }
   } else {
-    uiStore.addSearchCriteria(new ClientTagSearchCriteria(tagStore, 'tags', nodeData.id));
+    uiStore.addSearchCriteria(new ClientTagSearchCriteria('tags', nodeData.id));
   }
 };
 
@@ -124,7 +124,7 @@ document.body.appendChild(PreviewTag);
 
 const TagItem = observer((props: ITagItemProps) => {
   const { nodeData, dispatch, expansion, isEditing, submit, pos, select, showContextMenu } = props;
-  const { uiStore, tagStore } = useStore();
+  const { uiStore } = useStore();
   const dndData = useTagDnD();
 
   const handleContextMenu = useCallback(
@@ -305,14 +305,14 @@ const TagItem = observer((props: ITagItemProps) => {
         if (nodeData.isSearched) {
           // if already searched, un-search
           const crit = uiStore.searchCriteriaList.find(
-            (c) => c instanceof ClientTagSearchCriteria && c.value.includes(nodeData.id),
+            (c) => c instanceof ClientTagSearchCriteria && c.value === nodeData.id,
           );
           if (crit) {
             uiStore.removeSearchCriteria(crit);
           }
         } else {
           // otherwise, search it
-          const query = new ClientTagSearchCriteria(tagStore, 'tags', nodeData.id, nodeData.name);
+          const query = new ClientTagSearchCriteria('tags', nodeData.id, 'containsRecursively');
           if (event.ctrlKey || event.metaKey) {
             if (!nodeData.isSearched) {
               uiStore.addSearchCriteria(query);
@@ -323,7 +323,7 @@ const TagItem = observer((props: ITagItemProps) => {
         }
       });
     },
-    [nodeData, tagStore, uiStore],
+    [nodeData, uiStore],
   );
 
   const handleRename = useCallback(() => dispatch(Factory.enableEditing(nodeData.id)), [
@@ -443,7 +443,7 @@ const customKeys = (
 
     case 'Enter':
       event.stopPropagation();
-      toggleQuery(nodeData, uiStore, tagStore);
+      toggleQuery(nodeData, uiStore);
       break;
 
     case 'Delete':

--- a/src/frontend/containers/Settings/index.tsx
+++ b/src/frontend/containers/Settings/index.tsx
@@ -557,6 +557,42 @@ const Shortcuts = observer(() => {
   );
 });
 
+const StartUpBehavior = observer(() => {
+  const { uiStore } = useStore();
+
+  const [isAutoUpdateEnabled, setAutoUpdateEnabled] = useState(
+    RendererMessenger.isCheckUpdatesOnStartupEnabled(),
+  );
+
+  const toggleAutoUpdate = useCallback(() => {
+    RendererMessenger.toggleCheckUpdatesOnStartup();
+    setAutoUpdateEnabled((isOn) => !isOn);
+  }, []);
+
+  return (
+    <>
+      <h2>Start-up behavior</h2>
+      <h3>Remember last search query</h3>
+      <fieldset>
+        <legend>
+          Will restore the search query you had open when you last quit Allusion, so the same images
+          will be shown in the gallery
+        </legend>
+        <Toggle
+          checked={uiStore.isRememberSearchEnabled}
+          onChange={uiStore.toggleRememberSearchQuery}
+        />
+      </fieldset>
+
+      <h3>Automatic updates</h3>
+      <fieldset>
+        <legend>Check for updates when starting Allusion</legend>
+        <Toggle checked={isAutoUpdateEnabled} onChange={toggleAutoUpdate} />
+      </fieldset>
+    </>
+  );
+});
+
 const Advanced = observer(() => {
   const { uiStore, fileStore } = useStore();
   const thumbnailDirectory = uiStore.thumbnailDirectory;
@@ -605,15 +641,6 @@ const Advanced = observer(() => {
     }
   };
 
-  const [isAutoUpdateEnabled, setAutoUpdateEnabled] = useState(
-    RendererMessenger.isCheckUpdatesOnStartupEnabled(),
-  );
-
-  const toggleAutoUpdate = useCallback(() => {
-    RendererMessenger.toggleCheckUpdatesOnStartup();
-    setAutoUpdateEnabled((isOn) => !isOn);
-  }, []);
-
   return (
     <>
       <h2>Storage</h2>
@@ -650,12 +677,6 @@ const Advanced = observer(() => {
           text="Toggle DevTools"
         />
       </ButtonGroup>
-
-      <h2>Automatic updates</h2>
-      <fieldset>
-        <legend>Check for updates when starting Allusion</legend>
-        <Toggle checked={isAutoUpdateEnabled} onChange={toggleAutoUpdate} />
-      </fieldset>
     </>
   );
 });
@@ -668,6 +689,10 @@ const SETTINGS_TABS: () => TabItem[] = () => [
   {
     label: 'Shortcuts',
     content: <Shortcuts />,
+  },
+  {
+    label: 'Start-up behavior',
+    content: <StartUpBehavior />,
   },
   {
     label: 'Image formats',

--- a/src/frontend/stores/FileStore.ts
+++ b/src/frontend/stores/FileStore.ts
@@ -298,10 +298,10 @@ class FileStore {
     try {
       const { uiStore } = this.rootStore;
       uiStore.clearSearchCriteriaList();
-      const criteria = new ClientTagSearchCriteria(this.rootStore.tagStore, 'tags');
+      const criteria = new ClientTagSearchCriteria('tags');
       uiStore.searchCriteriaList.push(criteria);
       const fetchedFiles = await this.backend.searchFiles(
-        criteria.serialize(),
+        criteria.serialize(this.rootStore),
         this.orderBy,
         this.fileOrder,
         uiStore.searchMatchAny,
@@ -378,7 +378,9 @@ class FileStore {
 
   @action.bound async fetchFilesByQuery() {
     const { uiStore } = this.rootStore;
-    const criteria = this.rootStore.uiStore.searchCriteriaList.map((c) => c.serialize());
+    const criteria = this.rootStore.uiStore.searchCriteriaList.map((c) =>
+      c.serialize(this.rootStore),
+    );
     if (criteria.length === 0) {
       return this.fetchAllFiles();
     }
@@ -476,6 +478,10 @@ class FileStore {
       prefs[field] = this[field];
     }
     localStorage.setItem(FILE_STORAGE_KEY, JSON.stringify(prefs));
+  }
+
+  clearPersistentPreferences() {
+    localStorage.removeItem(FILE_STORAGE_KEY);
   }
 
   @action private async removeThumbnail(path: string) {
@@ -625,7 +631,7 @@ class FileStore {
 
   /** Initializes the total and untagged file counters by querying the database with count operations */
   async refetchFileCounts() {
-    const noTagsCriteria = new ClientTagSearchCriteria(this.rootStore.tagStore, 'tags').serialize();
+    const noTagsCriteria = new ClientTagSearchCriteria('tags').serialize(this.rootStore);
     const numUntaggedFiles = await this.backend.countFiles(noTagsCriteria);
     const numTotalFiles = await this.backend.countFiles();
     runInAction(() => {

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -72,13 +72,18 @@ class RootStore {
       const isSlideMode = this.uiStore.isSlideMode;
 
       // There may already be a search already present, recovered from a previous session
-      const fileStorerInit =
-        this.uiStore.searchCriteriaList.length > 0
-          ? this.fileStore.fetchFilesByQuery
-          : this.fileStore.fetchAllFiles;
+      const fileStoreInit =
+        this.uiStore.searchCriteriaList.length === 0
+          ? this.fileStore.fetchAllFiles
+          : () => {
+              // When searching by criteria, the file counts won't be set (only when fetching all files),
+              // so fetch them manually
+              this.fileStore.refetchFileCounts().catch(console.error);
+              return this.fileStore.fetchFilesByQuery();
+            };
 
       // Load the files already in the database so user instantly sees their images
-      fileStorerInit().then(() => {
+      fileStoreInit().then(() => {
         this.tagStore.initializeFileCounts(this.fileStore.fileList);
 
         // If slide mode was recovered from previous session, it's disabled by setContentQuery :/

--- a/src/frontend/stores/RootStore.ts
+++ b/src/frontend/stores/RootStore.ts
@@ -47,6 +47,8 @@ class RootStore {
     this.clearDatabase = async () => {
       await backend.clearDatabase();
       RendererMessenger.clearDatabase();
+      this.uiStore.clearPersistentPreferences();
+      this.fileStore.clearPersistentPreferences();
     };
   }
 
@@ -63,10 +65,29 @@ class RootStore {
     // The preview window is opened while the locations are already watched. The
     // files are fetched based on the file selection.
     if (!isPreviewWindow) {
+      // Then, restore preferences, which affects how the file store initializes
+      // It depends on tag store being intialized for reconstructing search criteria
+      this.uiStore.recoverPersistentPreferences();
+      this.fileStore.recoverPersistentPreferences();
+      const isSlideMode = this.uiStore.isSlideMode;
+
+      // There may already be a search already present, recovered from a previous session
+      const fileStorerInit =
+        this.uiStore.searchCriteriaList.length > 0
+          ? this.fileStore.fetchFilesByQuery
+          : this.fileStore.fetchAllFiles;
+
       // Load the files already in the database so user instantly sees their images
-      this.fileStore
-        .fetchAllFiles()
-        .then(() => this.tagStore.initializeFileCounts(this.fileStore.fileList));
+      fileStorerInit().then(() => {
+        this.tagStore.initializeFileCounts(this.fileStore.fileList);
+
+        // If slide mode was recovered from previous session, it's disabled by setContentQuery :/
+        // hacky workaround
+        if (isSlideMode) {
+          this.uiStore.enableSlideMode();
+        }
+      });
+
       // Then, look for any new or removed images, and refetch if necessary
       this.locationStore.watchLocations().then((foundNewFiles) => {
         if (foundNewFiles) this.fileStore.refetch();

--- a/src/frontend/stores/TagStore.ts
+++ b/src/frontend/stores/TagStore.ts
@@ -88,7 +88,7 @@ class TagStore {
 
   isSearched(tag: ClientTag): boolean {
     return this.rootStore.uiStore.searchCriteriaList.some(
-      (c) => c instanceof ClientTagSearchCriteria && c.value.includes(tag.id),
+      (c) => c instanceof ClientTagSearchCriteria && c.value === tag.id,
     );
   }
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -3,7 +3,11 @@ import { action, computed, makeObservable, observable, observe } from 'mobx';
 import { getDefaultThumbnailDirectory } from 'src/config';
 import { ClientFile, IFile } from 'src/entities/File';
 import { ID } from 'src/entities/ID';
-import { ClientBaseCriteria, ClientTagSearchCriteria } from 'src/entities/SearchCriteria';
+import {
+  ClientBaseCriteria,
+  ClientTagSearchCriteria,
+  SearchCriteria,
+} from 'src/entities/SearchCriteria';
 import { ClientTag } from 'src/entities/Tag';
 import { RendererMessenger } from 'src/Messaging';
 import { IS_PREVIEW_WINDOW } from 'src/renderer';
@@ -103,6 +107,11 @@ const PersistentPreferenceFields: Array<keyof UiStore> = [
   'isThumbnailFilenameOverlayEnabled',
   'outlinerWidth',
   'inspectorWidth',
+  'isRememberSearchEnabled',
+  // the following are only restored when isRememberSearchEnabled is enabled
+  'isSlideMode',
+  'firstItem',
+  'searchMatchAny',
 ];
 
 class UiStore {
@@ -136,6 +145,8 @@ class UiStore {
   /** Whether to show the tags on images in the content view */
   @observable isThumbnailTagOverlayEnabled: boolean = true;
   @observable isThumbnailFilenameOverlayEnabled: boolean = false;
+  /** Whether to restore the last search query on start-up */
+  @observable isRememberSearchEnabled: boolean = false;
   /** Index of the first item in the viewport. Also acts as the current item shown in slide mode */
   // TODO: Might be better to store the ID to the file. I believe we were storing the index for performance, but we have instant conversion between index/ID now
   @observable firstItem: number = 0;
@@ -161,14 +172,20 @@ class UiStore {
 
   @observable readonly hotkeyMap: IHotkeyMap = observable(defaultHotkeyMap);
 
+  private debouncedStorePersistentPreferences: () => void;
+
   constructor(rootStore: RootStore) {
     this.rootStore = rootStore;
     makeObservable(this);
 
     // Store preferences immediately when anything is changed
+    this.debouncedStorePersistentPreferences = debounce(this.storePersistentPreferences, 200).bind(
+      this,
+    );
     if (!IS_PREVIEW_WINDOW) {
-      const debouncedPersist = debounce(this.storePersistentPreferences, 200).bind(this);
-      PersistentPreferenceFields.forEach((f) => observe(this, f, debouncedPersist));
+      PersistentPreferenceFields.forEach((f) =>
+        observe(this, f, this.debouncedStorePersistentPreferences),
+      );
     }
   }
 
@@ -255,6 +272,7 @@ class UiStore {
 
   @action.bound enableSlideMode() {
     this.isSlideMode = true;
+    this.updateWindowTitle();
   }
 
   @action.bound disableSlideMode() {
@@ -264,6 +282,7 @@ class UiStore {
 
   @action.bound toggleSlideMode() {
     this.isSlideMode = !this.isSlideMode;
+    this.updateWindowTitle();
   }
 
   /** This does not actually set the window to full-screen, just for bookkeeping! Use RendererMessenger instead */
@@ -285,6 +304,10 @@ class UiStore {
 
   @action.bound toggleThumbnailFilenameOverlay() {
     this.isThumbnailFilenameOverlayEnabled = !this.isThumbnailFilenameOverlayEnabled;
+  }
+
+  @action.bound toggleRememberSearchQuery() {
+    this.isRememberSearchEnabled = !this.isRememberSearchEnabled;
   }
 
   @action.bound openOutliner() {
@@ -575,6 +598,7 @@ class UiStore {
   /////////////////// Search Actions ///////////////////
   @action.bound clearSearchCriteriaList() {
     if (this.searchCriteriaList.length > 0) {
+      this.searchCriteriaList.forEach((c) => c.dispose());
       this.searchCriteriaList.clear();
       this.viewAllContent();
     }
@@ -583,14 +607,17 @@ class UiStore {
   @action.bound addSearchCriteria(query: Exclude<FileSearchCriteria, 'key'>) {
     this.searchCriteriaList.push(query);
     this.viewQueryContent();
+    query.observe(this.debouncedStorePersistentPreferences);
   }
 
   @action.bound addSearchCriterias(queries: Exclude<FileSearchCriteria[], 'key'>) {
     this.searchCriteriaList.push(...queries);
+    queries.forEach((query) => query.observe(this.debouncedStorePersistentPreferences));
     this.viewQueryContent();
   }
 
   @action.bound removeSearchCriteria(query: FileSearchCriteria) {
+    query.dispose();
     this.searchCriteriaList.remove(query);
     if (this.searchCriteriaList.length > 0) {
       this.viewQueryContent();
@@ -604,7 +631,12 @@ class UiStore {
   }
 
   @action.bound replaceSearchCriterias(queries: Exclude<FileSearchCriteria[], 'key'>) {
+    this.searchCriteriaList.forEach((c) => c.dispose());
+
     this.searchCriteriaList.replace(queries);
+
+    queries.forEach((query) => query.observe(this.debouncedStorePersistentPreferences));
+
     if (this.searchCriteriaList.length > 0) {
       this.viewQueryContent();
     } else {
@@ -613,7 +645,10 @@ class UiStore {
   }
 
   @action.bound removeSearchCriteriaByIndex(i: number) {
-    this.searchCriteriaList.splice(i, 1);
+    const removedCrits = this.searchCriteriaList.splice(i, 1);
+
+    removedCrits.forEach((c) => c.dispose());
+
     if (this.searchCriteriaList.length > 0) {
       this.viewQueryContent();
     } else {
@@ -622,21 +657,18 @@ class UiStore {
   }
 
   @action.bound addTagSelectionToCriteria() {
-    this.addSearchCriterias(
-      Array.from(
-        this.tagSelection,
-        (tag) => new ClientTagSearchCriteria(this.rootStore.tagStore, 'tags', tag.id),
-      ),
+    const newCrits = Array.from(
+      this.tagSelection,
+      (tag) => new ClientTagSearchCriteria('tags', tag.id),
     );
+    newCrits.forEach((crit) => crit.observe(this.debouncedStorePersistentPreferences));
+    this.addSearchCriterias(newCrits);
     this.clearTagSelection();
   }
 
   @action.bound replaceCriteriaWithTagSelection() {
     this.replaceSearchCriterias(
-      Array.from(
-        this.tagSelection,
-        (tag) => new ClientTagSearchCriteria(this.rootStore.tagStore, 'tags', tag.id),
-      ),
+      Array.from(this.tagSelection, (tag) => new ClientTagSearchCriteria('tags', tag.id)),
     );
     this.clearTagSelection();
   }
@@ -644,7 +676,9 @@ class UiStore {
   @action.bound replaceCriteriaItem(oldCrit: FileSearchCriteria, crit: FileSearchCriteria) {
     const index = this.searchCriteriaList.indexOf(oldCrit);
     if (index !== -1) {
+      this.searchCriteriaList[index].dispose();
       this.searchCriteriaList[index] = crit;
+      crit.observe(this.debouncedStorePersistentPreferences);
       this.viewQueryContent();
     }
   }
@@ -763,7 +797,23 @@ class UiStore {
         Object.entries<string>(prefs.hotkeyMap).forEach(
           ([k, v]) => k in defaultHotkeyMap && (this.hotkeyMap[k as keyof IHotkeyMap] = v),
         );
-        console.info('recovered', prefs.hotkeyMap);
+
+        this.isRememberSearchEnabled = Boolean(prefs.isRememberSearchEnabled);
+        if (this.isRememberSearchEnabled) {
+          // If remember search criteria, restore the search criteria list...
+          const serializedCriteriaList: SearchCriteria<IFile>[] = JSON.parse(
+            prefs.searchCriteriaList || '[]',
+          );
+          const newCrits = serializedCriteriaList.map((c) => ClientBaseCriteria.deserialize(c));
+          this.searchCriteriaList.push(...newCrits);
+          newCrits.forEach((crit) => crit.observe(this.debouncedStorePersistentPreferences));
+
+          // and other content-related options. So it's just like you never closed Allusion!
+          this.firstItem = prefs.firstItem;
+          this.searchMatchAny = prefs.searchMatchAny;
+          this.isSlideMode = prefs.isSlideMode;
+        }
+        console.info('recovered', prefs);
       } catch (e) {
         console.error('Cannot parse persistent preferences', e);
       }
@@ -785,7 +835,17 @@ class UiStore {
     for (const field of PersistentPreferenceFields) {
       prefs[field] = this[field];
     }
+
+    // searchCriteriaList can't be observed; do it manually
+    prefs['searchCriteriaList'] = JSON.stringify(
+      this.searchCriteriaList.map((c) => c.serialize(this.rootStore)),
+    );
+
     localStorage.setItem(PREFERENCES_STORAGE_KEY, JSON.stringify(prefs));
+  }
+
+  clearPersistentPreferences() {
+    localStorage.removeItem(PREFERENCES_STORAGE_KEY);
   }
 
   /////////////////// Helper methods ///////////////////

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -95,11 +95,6 @@ if (IS_PREVIEW_WINDOW) {
   RendererMessenger.onClosedPreviewWindow(() => {
     rootStore.uiStore.closePreviewWindow();
   });
-
-  // Load persistent preferences
-  rootStore.uiStore.recoverPersistentPreferences();
-  rootStore.fileStore.recoverPersistentPreferences();
-
   // Recover global preferences
   try {
     const window_preferences = localStorage.getItem(WINDOW_STORAGE_KEY);


### PR DESCRIPTION
- Added a "Start-up behavior" tab to the settings panel:
![image](https://user-images.githubusercontent.com/5946427/145102682-f2d0f2f8-5614-4069-8cbd-66087664212a.png)

- The search criteria, scroll position (`firstItem`), `isSlideModeEnabled` are all recovered on start-up if this new option is enabled. So it does more than just remembering the search, maybe rename it to "remember the previous state on startup"?
![allusion-remember-search](https://user-images.githubusercontent.com/5946427/145102853-6d0ee000-741a-4c01-bd7f-432a43d605a5.gif)

This required refactoring the SearchCriteria entities a bit so they can be serialized and deserialized. It also makes it possible to have a list of recent searches, and to have a list of saved searches, if they can fit in UI/UX-wise. Currently experimenting with a recent search dropdown in the [search-history](https://github.com/allusion-app/Allusion/tree/search-history) branch