### PR TITLE
Added 'Open External' keyboard shortcut

### DIFF
--- a/common/config.ts
+++ b/common/config.ts
@@ -19,6 +19,8 @@ const isRenderer = process.type === 'renderer';
 // The values 600 : 400 needed to be flipped in order to get 600 on OSX Retina
 export const thumbnailMaxSize = isRenderer && globalThis.devicePixelRatio >= 1.5 ? 400 : 600;
 
+export const maxNumberOfExternalFilesBeforeWarning = 9;
+
 /**
  * Creates the body of a bug report
  * @param error The error message (error.stack if available)

--- a/src/frontend/components/WarningAlert.tsx
+++ b/src/frontend/components/WarningAlert.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import { action } from 'mobx';
+
+import { useStore } from 'src/frontend/contexts/StoreContext';
+import { IconSet } from 'widgets';
+import { Alert, DialogButton } from 'widgets/popovers';
+
+export const ManyOpenExternal = observer(() => {
+  const { uiStore } = useStore();
+  const selection = uiStore.fileSelection;
+
+  const handleConfirm = action(() => {
+    uiStore.closeManyExternalFiles();
+    uiStore.openExternal(false);
+  });
+
+  return (
+    <Alert
+      open={uiStore.isManyExternalFilesOpen}
+      title={`Are you sure you want to open so many files (${selection.size}) in their respective external apps?`}
+      icon={IconSet.WARNING}
+      type="warning"
+      primaryButtonText="Confirm"
+      defaultButton={DialogButton.PrimaryButton}
+      onClick={(button) => {
+        if (button !== DialogButton.CloseButton) {
+          handleConfirm();
+        }
+        uiStore.closeManyExternalFiles();
+      }}
+    >
+      <p>If your hardware is not powerful enough, it could overload your CPU capacity!</p>
+      <div className="deletion-confirmation-list">
+        {Array.from(selection).map((f) => (
+          <div key={f.id}>{f.absolutePath}</div>
+        ))}
+      </div>
+    </Alert>
+  );
+});

--- a/src/frontend/components/WarningAlert.tsx
+++ b/src/frontend/components/WarningAlert.tsx
@@ -18,7 +18,7 @@ export const ManyOpenExternal = observer(() => {
   return (
     <Alert
       open={uiStore.isManyExternalFilesOpen}
-      title={`Are you sure you want to open so many files (${selection.size}) in their respective external apps?`}
+      title={`Are you sure you want to open ${selection.size} images in their default application?`}
       icon={IconSet.WARNING}
       type="warning"
       primaryButtonText="Confirm"
@@ -30,7 +30,7 @@ export const ManyOpenExternal = observer(() => {
         uiStore.closeManyExternalFiles();
       }}
     >
-      <p>If your hardware is not powerful enough, it could overload your CPU capacity!</p>
+      <p>This may severely slow down your computer, to the point of it becoming unresponsive.</p>
       <div className="deletion-confirmation-list">
         {Array.from(selection).map((f) => (
           <div key={f.id}>{f.absolutePath}</div>

--- a/src/frontend/containers/ContentView/index.tsx
+++ b/src/frontend/containers/ContentView/index.tsx
@@ -14,6 +14,7 @@ import { useTagDnD } from 'src/frontend/contexts/TagDnDContext';
 import { MoveFilesToTrashBin } from 'src/frontend/components/RemovalAlert';
 import { useAction } from 'src/frontend/hooks/mobx';
 import useIsWindowMaximized from 'src/frontend/hooks/useIsWindowMaximized';
+import { ManyOpenExternal } from 'src/frontend/components/WarningAlert';
 
 const ContentView = observer(() => {
   const {
@@ -108,6 +109,7 @@ const Content = observer(() => {
     >
       <Layout contentRect={contentRect} />
       <MoveFilesToTrashBin />
+      <ManyOpenExternal />
     </div>
   );
 });

--- a/src/frontend/containers/ContentView/menu-items.tsx
+++ b/src/frontend/containers/ContentView/menu-items.tsx
@@ -81,7 +81,7 @@ export const ExternalAppMenuItems = observer(({ file }: { file: ClientFile }) =>
   return (
     <>
       <MenuItem
-        onClick={() => shell.openExternal(`file://${file.absolutePath}`).catch(console.error)}
+        onClick={() => uiStore.openExternal()}
         text="Open External"
         icon={IconSet.OPEN_EXTERNAL}
         disabled={file.isBroken}

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -414,9 +414,7 @@ class UiStore {
   }
 
   @action.bound closeMoveFilesToTrash() {
-    if (this.fileSelection.size > 0) {
-      this.isMoveFilesToTrashOpen = false;
-    }
+    this.isMoveFilesToTrashOpen = false;
   }
 
   @action.bound closeManyExternalFiles() {

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -1,3 +1,4 @@
+import { shell } from 'electron';
 import fse from 'fs-extra';
 import { action, computed, makeObservable, observable, observe } from 'mobx';
 import { ClientFile, IFile } from 'src/entities/File';
@@ -51,6 +52,7 @@ export interface IHotkeyMap {
 
   // Other
   openPreviewWindow: string;
+  openExternal: string;
 }
 
 // https://blueprintjs.com/docs/#core/components/hotkeys.dialog
@@ -72,6 +74,7 @@ export const defaultHotkeyMap: IHotkeyMap = {
   search: 'mod + f',
   advancedSearch: 'mod + shift + f',
   openPreviewWindow: 'space',
+  openExternal: 'mod + enter',
 };
 
 /**
@@ -343,6 +346,16 @@ class UiStore {
     if (document.activeElement && document.activeElement instanceof HTMLElement) {
       document.activeElement.blur();
     }
+  }
+
+  @action.bound openExternal() {
+    // Don't open when no files have been selected
+    if (this.fileSelection.size === 0) {
+      return;
+    }
+
+    const absolutePaths = Array.from(this.fileSelection, (file) => file.absolutePath);
+    absolutePaths.forEach((path) => shell.openExternal(`file://${path}`).catch(console.error));
   }
 
   @action.bound toggleInspector() {
@@ -748,6 +761,8 @@ class UiStore {
     } else if (matches(hotkeyMap.openPreviewWindow)) {
       this.openPreviewWindow();
       e.preventDefault(); // prevent scrolling with space when opening the preview window
+    } else if (matches(hotkeyMap.openExternal)) {
+      this.openExternal();
       // Search
     } else if (matches(hotkeyMap.search)) {
       (document.querySelector('.searchbar input') as HTMLElement).focus();

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -16,6 +16,7 @@ import { comboMatches, getKeyCombo, parseKeyCombo } from '../hotkeyParser';
 import { clamp, notEmpty } from 'common/core';
 import { debounce } from 'common/timeout';
 import RootStore from './RootStore';
+import { maxNumberOfExternalFilesBeforeWarning } from 'common/config';
 
 export const enum ViewMethod {
   List,
@@ -161,6 +162,8 @@ class UiStore {
   @observable isToolbarFileRemoverOpen: boolean = false;
   /** Dialog for moving files to the system's trash bin, and removing from Allusion's database */
   @observable isMoveFilesToTrashOpen: boolean = false;
+  /** Dialog to warn the user when he tries to open too many files externally */
+  @observable isManyExternalFilesOpen: boolean = false;
 
   // Selections
   // Observable arrays recommended like this here https://github.com/mobxjs/mobx/issues/669#issuecomment-269119270.
@@ -348,9 +351,14 @@ class UiStore {
     }
   }
 
-  @action.bound openExternal() {
+  @action.bound openExternal(warnIfTooManyFiles: boolean = true) {
     // Don't open when no files have been selected
     if (this.fileSelection.size === 0) {
+      return;
+    }
+
+    if (warnIfTooManyFiles && this.fileSelection.size > maxNumberOfExternalFilesBeforeWarning) {
+      this.isManyExternalFilesOpen = true;
       return;
     }
 
@@ -409,6 +417,10 @@ class UiStore {
     if (this.fileSelection.size > 0) {
       this.isMoveFilesToTrashOpen = false;
     }
+  }
+
+  @action.bound closeManyExternalFiles() {
+    this.isManyExternalFilesOpen = false;
   }
 
   @action.bound toggleToolbarTagPopover() {


### PR DESCRIPTION
Hello,

Following this issue I recently opened (#495), I added the keyboard shortcut "Open external" to the list of already existing shortcuts.
I set the default key combination to "Ctrl + Enter", I also thought of setting "Ctrl + Space" but after trying it, I found the former more natural.
Also, compared to the default "Right Click -> Open External" on a single entry, this shortcut opens all selected files.

As I did not find a contribution section, neither in the readme nor in the wiki, I do not know if you accept such pr. If not, I'm sorry for the inconvenience.