### PR TITLE
ZoomPan fixes

### DIFF
--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -483,7 +483,7 @@ export const CONTAINER_DEFAULT_STYLE = {
 
 function imageStyle({ top, left, scale }: ZoomPanState): CSSProperties {
   return {
-    transform: `translate3d(${left}px, ${top}px, 0) scale(${scale})`,
+    transform: `translate3d(${Math.trunc(left)}px, ${Math.trunc(top)}px, 0) scale(${scale})`,
   };
 }
 

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -160,8 +160,7 @@ export default class ZoomPan extends React.Component<ZoomPanProps, ZoomPanState>
       }
     } else if (event.deltaY < 0) {
       if (scale < this.props.maxScale) {
-        const transform = getZoomedTransform(this.props, this.state, scale * 1.1, point, 0);
-        this.setState(transform);
+        this.zoomInStep(point);
         tryPreventDefault(event);
       }
     }
@@ -237,8 +236,13 @@ export default class ZoomPan extends React.Component<ZoomPanProps, ZoomPanState>
     this.startAnimation(animateTransform(transform, ANIMATION_SPEED, this.setState));
   }
 
+  zoomInStep(center: Vec2) {
+    const transform = getZoomedTransform(this.props, this.state, this.state.scale * 1.1, center, 0);
+    this.setState(transform);
+  }
+
   zoomOut(center: Vec2) {
-    const transform = getZoomedTransform(this.props, this.state, this.state.scale * 0.9, center, 0);
+    const transform = getZoomedTransform(this.props, this.state, this.state.scale / 1.1, center, 0);
     this.setState(transform);
   }
 


### PR DESCRIPTION
Just a couple of small fixes for the slide pane.
- Prevents half-pixel positioning to avoid blur at 100% zoom
- Makes zooming in and out the same increment