### PR TITLE
Add support for mp4, webm, and ogg

### DIFF
--- a/common/fs.ts
+++ b/common/fs.ts
@@ -43,6 +43,10 @@ export async function isDirEmpty(dir: string) {
   return dirContents.length === 0 || (dirContents.length === 1 && dirContents[0] === '.DS_Store');
 }
 
+export function isFileExtensionVideo(fileExtension: string) {
+  return (fileExtension === 'webm' || fileExtension === 'mp4' || fileExtension === 'ogg');
+}
+
 function hashString(s: string) {
   let hash = 0;
   let chr = 0;

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -59,7 +59,7 @@
     pointer-events: none;
   }
 
-  > img {
+  > :is(img, video) {
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -72,7 +72,7 @@
   &[data-dnd-target='true'] {
     background-color: var(--accent-color-yellow);
 
-    img {
+    :is(img, video) {
       clip-path: inset(0.5rem round 0.125rem);
     }
   }
@@ -81,16 +81,14 @@
 [aria-selected='true'] > .thumbnail {
   // If selected, show a blue border
   background-color: var(--accent-color);
-  > img,
-  > .image-error {
+  > :is(img, video) {
     clip-path: inset(0.25rem round 0.125rem); // old design
   }
 
   // If selected AND drop target: big yellow border
   &[data-dnd-target='true'] {
     background-color: var(--accent-color-yellow);
-    > img,
-    > .image-error {
+    > :is(img, video) {
       clip-path: inset(0.5rem round 0.125rem);
     }
   }
@@ -278,7 +276,7 @@
     width: var(--thumbnail-size);
   }
 
-  .col-name > img {
+  .col-name > :is(img, video) {
     object-fit: cover;
     padding: 2px;
   }
@@ -330,11 +328,11 @@
   position: relative;
 }
 
-.thumbnail-square img {
+.thumbnail-square img, video {
   background-position: center;
   object-fit: cover;
 }
-.thumbnail-letterbox img {
+.thumbnail-letterbox img, video {
   object-fit: contain;
 }
 
@@ -422,7 +420,7 @@
     right: 0;
   }
 
-  img {
+  img, video {
     // Let the compositor know that the image will transform for better performance
     will-change: transform;
   

--- a/src/api/file.ts
+++ b/src/api/file.ts
@@ -53,5 +53,8 @@ export const IMG_EXTENSIONS = [
   // 'avif',
   // 'heic', // not supported by Sharp out of the box https://github.com/lovell/sharp/issues/2871
   // TODO: 'blend', raw, etc.?
+  'mp4',
+  'webm',
+  'ogg',
 ] as const;
-export type IMG_EXTENSIONS_TYPE = typeof IMG_EXTENSIONS[number];
+export type IMG_EXTENSIONS_TYPE = (typeof IMG_EXTENSIONS)[number];

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -152,6 +152,23 @@ export const Thumbnail = observer(({ file, mounted, forceNoThumbnail }: ItemProp
   } else if (imageSource.tag === 'ready') {
     if ('ok' in imageSource.value) {
       const is_lowres = file.width < 320 || file.height < 320;
+      // Alternative case where imageSource is a video
+      if (file.extension === 'webm' || file.extension === 'mp4' || file.extension === 'ogg') {
+        return (
+          <video
+            src={encodeFilePath(imageSource.value.ok)}
+            data-file-id={file.id}
+            onError={handleImageError}
+            style={
+              is_lowres && uiStore.upscaleMode == 'pixelated' ? { imageRendering: 'pixelated' } : {}
+            }
+            autoPlay
+            muted
+            loop
+          />
+        );
+      }
+
       return (
         <img
           src={encodeFilePath(imageSource.value.ok)}

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -20,6 +20,7 @@ interface ItemProps {
   forceNoThumbnail?: boolean;
   hovered?: boolean;
   galleryVideoPlaybackMode?: GalleryVideoPlaybackMode;
+  isSlideMode?: boolean;
 }
 
 interface MasonryItemProps extends ItemProps {
@@ -70,7 +71,14 @@ export const MasonryCell = observer(
               : (e: React.MouseEvent): void => {}
           }
         >
-          <Thumbnail mounted={mounted} file={file} forceNoThumbnail={forceNoThumbnail} hovered={isHovered} galleryVideoPlaybackMode={uiStore.galleryVideoPlaybackMode}/>
+          <Thumbnail
+            mounted={mounted}
+            file={file}
+            forceNoThumbnail={forceNoThumbnail}
+            hovered={isHovered}
+            galleryVideoPlaybackMode={uiStore.galleryVideoPlaybackMode}
+            isSlideMode={uiStore.isSlideMode}
+          />
         </div>
         {file.isBroken === true && !fileStore.showsMissingContent && (
           <IconButton
@@ -108,134 +116,154 @@ export const MasonryCell = observer(
 
 // TODO: When a filename contains https://x/y/z.abc?323 etc., it can't be found
 // e.g. %2F should be %252F on filesystems. Something to do with decodeURI, but seems like only on the filename - not the whole path
-export const Thumbnail = observer(({ file, mounted, forceNoThumbnail, hovered, galleryVideoPlaybackMode }: ItemProps) => {
-  const { uiStore, imageLoader } = useStore();
-  const { thumbnailPath, isBroken } = file;
-
-  // This will check whether a thumbnail exists, generate it if needed
-  const imageSource = usePromise(
+export const Thumbnail = observer(
+  ({
     file,
-    isBroken,
     mounted,
-    thumbnailPath,
-    uiStore.isList || !forceNoThumbnail,
-    async (file, isBroken, mounted, thumbnailPath, useThumbnail) => {
-      // If it is broken, only show thumbnail if it exists.
-      if (!mounted || isBroken === true) {
-        if (await fse.pathExists(thumbnailPath)) {
-          return thumbnailPath;
-        } else {
-          throw new Error('No thumbnail available.');
-        }
-      }
+    forceNoThumbnail,
+    hovered,
+    galleryVideoPlaybackMode,
+    isSlideMode,
+  }: ItemProps) => {
+    const { uiStore, imageLoader } = useStore();
+    const { thumbnailPath, isBroken } = file;
 
-      if (useThumbnail) {
-        const freshlyGenerated = await imageLoader.ensureThumbnail(file);
-        // The thumbnailPath of an image is always set, but may not exist yet.
-        // When the thumbnail is finished generating, the path will be changed to `${thumbnailPath}?v=1`.
-        if (freshlyGenerated) {
-          await when(() => file.thumbnailPath.endsWith('?v=1'), { timeout: 10000 });
-          if (!getThumbnail(file).endsWith('?v=1')) {
-            throw new Error('Thumbnail generation timeout.');
+    // This will check whether a thumbnail exists, generate it if needed
+    const imageSource = usePromise(
+      file,
+      isBroken,
+      mounted,
+      thumbnailPath,
+      uiStore.isList || !forceNoThumbnail,
+      async (file, isBroken, mounted, thumbnailPath, useThumbnail) => {
+        // If it is broken, only show thumbnail if it exists.
+        if (!mounted || isBroken === true) {
+          if (await fse.pathExists(thumbnailPath)) {
+            return thumbnailPath;
+          } else {
+            throw new Error('No thumbnail available.');
           }
         }
-        return getThumbnail(file);
-      } else {
-        const src = await imageLoader.getImageSrc(file);
-        if (src !== undefined) {
-          return src;
+
+        if (useThumbnail) {
+          const freshlyGenerated = await imageLoader.ensureThumbnail(file);
+          // The thumbnailPath of an image is always set, but may not exist yet.
+          // When the thumbnail is finished generating, the path will be changed to `${thumbnailPath}?v=1`.
+          if (freshlyGenerated) {
+            await when(() => file.thumbnailPath.endsWith('?v=1'), { timeout: 10000 });
+            if (!getThumbnail(file).endsWith('?v=1')) {
+              throw new Error('Thumbnail generation timeout.');
+            }
+          }
+          return getThumbnail(file);
         } else {
-          throw new Error('No thumbnail available.');
+          const src = await imageLoader.getImageSrc(file);
+          if (src !== undefined) {
+            return src;
+          } else {
+            throw new Error('No thumbnail available.');
+          }
         }
+      },
+    );
+
+    // Even though all thumbnail errors should be caught in the above usePromise,
+    // there is a chance that the image cannot be loaded, and we don't want to show broken image icons
+    const fileId = file.id;
+    const fileIdRef = useRef(fileId);
+    const [loadError, setLoadError] = useState(false);
+    const handleImageError = useCallback(() => {
+      if (fileIdRef.current === fileId) {
+        setLoadError(true);
       }
-    },
-  );
+    }, [fileId]);
+    useEffect(() => {
+      fileIdRef.current = fileId;
+      setLoadError(false);
+    }, [fileId]);
 
-  // Even though all thumbnail errors should be caught in the above usePromise,
-  // there is a chance that the image cannot be loaded, and we don't want to show broken image icons
-  const fileId = file.id;
-  const fileIdRef = useRef(fileId);
-  const [loadError, setLoadError] = useState(false);
-  const handleImageError = useCallback(() => {
-    if (fileIdRef.current === fileId) {
-      setLoadError(true);
-    }
-  }, [fileId]);
-  useEffect(() => {
-    fileIdRef.current = fileId;
-    setLoadError(false);
-  }, [fileId]);
-
-  // Plays and pauses video
-  const thumbnailRef = useRef<HTMLVideoElement>(null);
-  useEffect(() => {
-    if (thumbnailRef.current === null) {
-      return;
-    }
-    if (isFileExtensionVideo(file.extension)) {
+    // Plays and pauses video
+    const thumbnailRef = useRef<HTMLVideoElement>(null);
+    useEffect(() => {
+      if (thumbnailRef.current === null || !isFileExtensionVideo(file.extension)) {
+        return;
+      }
       if (hovered) {
         thumbnailRef.current.play();
       } else {
         thumbnailRef.current.pause();
         thumbnailRef.current.currentTime = 0;
       }
-    }
-  }, [thumbnailRef, hovered]);
-  useEffect(() => {
-    if (thumbnailRef.current !== null) {
-      if (isFileExtensionVideo(file.extension)) {
+    }, [thumbnailRef, hovered]);
+    useEffect(() => {
+      if (thumbnailRef.current === null || !isFileExtensionVideo(file.extension)) {
+        return;
+      }
+      if (galleryVideoPlaybackMode === 'auto') {
+        thumbnailRef.current.play();
+      } else {
+        thumbnailRef.current.pause();
+        thumbnailRef.current.currentTime = 0;
+      }
+    }, [thumbnailRef, galleryVideoPlaybackMode]);
+
+    // Pause video when slide mode, don't want to decode when video isn't visible
+    useEffect(() => {
+      if (thumbnailRef.current === null || !isFileExtensionVideo(file.extension)) {
+        return;
+      }
+      if (isSlideMode) {
+        thumbnailRef.current.pause();
+      } else {
         if (galleryVideoPlaybackMode === 'auto') {
           thumbnailRef.current.play();
-        } else {
-          thumbnailRef.current.pause();
-          thumbnailRef.current.currentTime = 0;
         }
       }
-    }
-  }, [thumbnailRef, galleryVideoPlaybackMode]);
+    }, [thumbnailRef, isSlideMode]);
 
-  if (!mounted) {
-    return <span className="image-placeholder" />;
-  } else if (loadError) {
-    return <span className="image-loading" />;
-  } else if (imageSource.tag === 'ready') {
-    if ('ok' in imageSource.value) {
-      const is_lowres = file.width < 320 || file.height < 320;
-      // TODO: add thumbnails to video for performance in gallery view
-      if (isFileExtensionVideo(file.extension)) {
-        const videoProps = {
-          src: encodeFilePath(imageSource.value.ok),
-          'data-file-id': file.id,
-          onError: handleImageError,
-          muted: true,
-          autoPlay: false,
-          loop: true,
-        };
-        if (galleryVideoPlaybackMode === 'auto' || hovered) {
-          videoProps.autoPlay = true;
-        }
-
-        return <video ref={thumbnailRef} {...videoProps} />;
-      }
-
-      return (
-        <img
-          src={encodeFilePath(imageSource.value.ok)}
-          alt=""
-          data-file-id={file.id}
-          onError={handleImageError}
-          style={
-            is_lowres && uiStore.upscaleMode == 'pixelated' ? { imageRendering: 'pixelated' } : {}
+    if (!mounted) {
+      return <span className="image-placeholder" />;
+    } else if (loadError) {
+      return <span className="image-loading" />;
+    } else if (imageSource.tag === 'ready') {
+      if ('ok' in imageSource.value) {
+        const is_lowres = file.width < 320 || file.height < 320;
+        // TODO: add thumbnails to video for performance in gallery view
+        if (isFileExtensionVideo(file.extension)) {
+          const videoProps = {
+            src: encodeFilePath(imageSource.value.ok),
+            'data-file-id': file.id,
+            onError: handleImageError,
+            muted: true,
+            autoPlay: false,
+            loop: true,
+          };
+          if (galleryVideoPlaybackMode === 'auto' || hovered) {
+            videoProps.autoPlay = true;
           }
-        />
-      );
+
+          return <video ref={thumbnailRef} {...videoProps} />;
+        }
+
+        return (
+          <img
+            src={encodeFilePath(imageSource.value.ok)}
+            alt=""
+            data-file-id={file.id}
+            onError={handleImageError}
+            style={
+              is_lowres && uiStore.upscaleMode == 'pixelated' ? { imageRendering: 'pixelated' } : {}
+            }
+          />
+        );
+      } else {
+        return <span className="image-error" />;
+      }
     } else {
-      return <span className="image-error" />;
+      return <span className="image-loading" />;
     }
-  } else {
-    return <span className="image-loading" />;
-  }
-});
+  },
+);
 
 const getThumbnail = action((file: ClientFile) => file.thumbnailPath);
 

--- a/src/frontend/containers/ContentView/GalleryItem.tsx
+++ b/src/frontend/containers/ContentView/GalleryItem.tsx
@@ -4,19 +4,22 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import fse from 'fs-extra';
 import { ClientFile } from 'src/entities/File';
 import { ellipsize, humanFileSize } from 'common/fmt';
-import { encodeFilePath } from 'common/fs';
+import { encodeFilePath, isFileExtensionVideo } from 'common/fs';
 import { IconButton, IconSet, Tag } from 'widgets';
 import { ITransform } from './Masonry/layout-helpers';
 import { ClientTag } from 'src/entities/Tag';
 import { useStore } from 'src/frontend/contexts/StoreContext';
 import { usePromise } from 'src/frontend/hooks/usePromise';
 import { CommandDispatcher, MousePointerEvent } from './Commands';
+import { GalleryVideoPlaybackMode } from 'src/frontend/stores/UiStore';
 
 interface ItemProps {
   file: ClientFile;
   mounted: boolean;
   // Will use the original image instead of the thumbnail
   forceNoThumbnail?: boolean;
+  hovered?: boolean;
+  galleryVideoPlaybackMode?: GalleryVideoPlaybackMode;
 }
 
 interface MasonryItemProps extends ItemProps {
@@ -32,8 +35,16 @@ export const MasonryCell = observer(
     transform: [width, height, top, left],
   }: MasonryItemProps) => {
     const { uiStore, fileStore } = useStore();
+    const [isHovered, setIsHovered] = useState(false);
     const style = { height, width, transform: `translate(${left}px,${top}px)` };
     const eventManager = useMemo(() => new CommandDispatcher(file), [file]);
+
+    const handleMouseEnter = useCallback((e: React.MouseEvent): void => {
+      setIsHovered(true);
+    }, []);
+    const handleMouseLeave = useCallback((e: React.MouseEvent): void => {
+      setIsHovered(false);
+    }, []);
 
     return (
       <div data-masonrycell aria-selected={uiStore.fileSelection.has(file)} style={style}>
@@ -48,8 +59,18 @@ export const MasonryCell = observer(
           onDragLeave={eventManager.dragLeave}
           onDrop={eventManager.drop}
           onDragEnd={eventManager.dragEnd}
+          onMouseEnter={
+            uiStore.galleryVideoPlaybackMode === 'hover' && isFileExtensionVideo(file.extension)
+              ? handleMouseEnter
+              : (e: React.MouseEvent): void => {}
+          }
+          onMouseLeave={
+            uiStore.galleryVideoPlaybackMode === 'hover' && isFileExtensionVideo(file.extension)
+              ? handleMouseLeave
+              : (e: React.MouseEvent): void => {}
+          }
         >
-          <Thumbnail mounted={mounted} file={file} forceNoThumbnail={forceNoThumbnail} />
+          <Thumbnail mounted={mounted} file={file} forceNoThumbnail={forceNoThumbnail} hovered={isHovered} galleryVideoPlaybackMode={uiStore.galleryVideoPlaybackMode}/>
         </div>
         {file.isBroken === true && !fileStore.showsMissingContent && (
           <IconButton
@@ -87,7 +108,7 @@ export const MasonryCell = observer(
 
 // TODO: When a filename contains https://x/y/z.abc?323 etc., it can't be found
 // e.g. %2F should be %252F on filesystems. Something to do with decodeURI, but seems like only on the filename - not the whole path
-export const Thumbnail = observer(({ file, mounted, forceNoThumbnail }: ItemProps) => {
+export const Thumbnail = observer(({ file, mounted, forceNoThumbnail, hovered, galleryVideoPlaybackMode }: ItemProps) => {
   const { uiStore, imageLoader } = useStore();
   const { thumbnailPath, isBroken } = file;
 
@@ -145,6 +166,34 @@ export const Thumbnail = observer(({ file, mounted, forceNoThumbnail }: ItemProp
     setLoadError(false);
   }, [fileId]);
 
+  // Plays and pauses video
+  const thumbnailRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (thumbnailRef.current === null) {
+      return;
+    }
+    if (isFileExtensionVideo(file.extension)) {
+      if (hovered) {
+        thumbnailRef.current.play();
+      } else {
+        thumbnailRef.current.pause();
+        thumbnailRef.current.currentTime = 0;
+      }
+    }
+  }, [thumbnailRef, hovered]);
+  useEffect(() => {
+    if (thumbnailRef.current !== null) {
+      if (isFileExtensionVideo(file.extension)) {
+        if (galleryVideoPlaybackMode === 'auto') {
+          thumbnailRef.current.play();
+        } else {
+          thumbnailRef.current.pause();
+          thumbnailRef.current.currentTime = 0;
+        }
+      }
+    }
+  }, [thumbnailRef, galleryVideoPlaybackMode]);
+
   if (!mounted) {
     return <span className="image-placeholder" />;
   } else if (loadError) {
@@ -152,21 +201,21 @@ export const Thumbnail = observer(({ file, mounted, forceNoThumbnail }: ItemProp
   } else if (imageSource.tag === 'ready') {
     if ('ok' in imageSource.value) {
       const is_lowres = file.width < 320 || file.height < 320;
-      // Alternative case where imageSource is a video
-      if (file.extension === 'webm' || file.extension === 'mp4' || file.extension === 'ogg') {
-        return (
-          <video
-            src={encodeFilePath(imageSource.value.ok)}
-            data-file-id={file.id}
-            onError={handleImageError}
-            style={
-              is_lowres && uiStore.upscaleMode == 'pixelated' ? { imageRendering: 'pixelated' } : {}
-            }
-            autoPlay
-            muted
-            loop
-          />
-        );
+      // TODO: add thumbnails to video for performance in gallery view
+      if (isFileExtensionVideo(file.extension)) {
+        const videoProps = {
+          src: encodeFilePath(imageSource.value.ok),
+          'data-file-id': file.id,
+          onError: handleImageError,
+          muted: true,
+          autoPlay: false,
+          loop: true,
+        };
+        if (galleryVideoPlaybackMode === 'auto' || hovered) {
+          videoProps.autoPlay = true;
+        }
+
+        return <video ref={thumbnailRef} {...videoProps} />;
       }
 
       return (

--- a/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/ZoomPan.tsx
@@ -31,9 +31,7 @@ const ANIMATION_SPEED = 0.1;
 export type SlideTransform = Transform;
 
 export interface ZoomPanProps {
-  children: (
-    props: React.ImgHTMLAttributes<HTMLImageElement>,
-  ) => React.ReactElement<HTMLImageElement>;
+  children: (props: React.ImgHTMLAttributes<HTMLElement>) => React.ReactElement<HTMLElement>;
   initialScale: number | 'auto';
   minScale: number;
   maxScale: number;

--- a/src/frontend/containers/ContentView/SlideMode/index.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/index.tsx
@@ -7,7 +7,7 @@ import { ClientFile } from 'src/entities/File';
 import { useStore } from 'src/frontend/contexts/StoreContext';
 import { useAction, useComputed } from 'src/frontend/hooks/mobx';
 import { usePromise } from 'src/frontend/hooks/usePromise';
-import { encodeFilePath } from 'common/fs';
+import { encodeFilePath, isFileExtensionVideo } from 'common/fs';
 import { Button, IconSet, Split } from 'widgets';
 import Inspector from '../../Inspector';
 import { CommandDispatcher } from '../Commands';
@@ -124,11 +124,7 @@ const SlideView = observer(({ width, height }: SlideViewProps) => {
       if (!isLast.get() && uiStore.firstItem + 1 < fileStore.fileList.length) {
         const nextFile = fileStore.fileList[uiStore.firstItem + 1];
         let nextImg: any;
-        if (
-          nextFile.extension === 'mp4' ||
-          nextFile.extension === 'webm' ||
-          nextFile.extension === 'ogg'
-        ) {
+        if (isFileExtensionVideo(nextFile.extension)) {
           nextImg = document.createElement('video');
         } else {
           nextImg = new Image();
@@ -140,11 +136,7 @@ const SlideView = observer(({ width, height }: SlideViewProps) => {
       if (!isFirst.get() && fileStore.fileList.length > 0) {
         const prevFile = fileStore.fileList[uiStore.firstItem - 1];
         let prevImg: any;
-        if (
-          prevFile.extension === 'mp4' ||
-          prevFile.extension === 'webm' ||
-          prevFile.extension === 'ogg'
-        ) {
+        if (isFileExtensionVideo(prevFile.extension)) {
           prevImg = document.createElement('video');
         } else {
           prevImg = new Image();
@@ -253,7 +245,7 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({
           const dimension = await new Promise<{ src: string; dimension: Vec2 }>(
             (resolve, reject) => {
               let img;
-              if (fileExtension === 'webm' || fileExtension === 'mp4' || fileExtension === 'ogg') {
+              if (isFileExtensionVideo(fileExtension)) {
                 img = document.createElement('video');
                 img.onload = function (this: any) {
                   // TODO: would be better to resolve once transition is complete: for large resolution images, the transition freezes for ~.4s bc of a re-paint task when the image changes
@@ -304,7 +296,7 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({
     const minScale = Math.min(0.1, Math.min(width / dimension[0], height / dimension[1]));
 
     // Alternative case for videos
-    if (file.extension === 'webm' || file.extension === 'mp4' || file.extension === 'ogg') {
+    if (isFileExtensionVideo(file.extension)) {
       return (
         <ZoomPan
           position="center"

--- a/src/frontend/containers/ContentView/SlideMode/index.tsx
+++ b/src/frontend/containers/ContentView/SlideMode/index.tsx
@@ -122,15 +122,33 @@ const SlideView = observer(({ width, height }: SlideViewProps) => {
     let isEffectRunning = true;
     const dispose = autorun(() => {
       if (!isLast.get() && uiStore.firstItem + 1 < fileStore.fileList.length) {
-        const nextImg = new Image();
         const nextFile = fileStore.fileList[uiStore.firstItem + 1];
+        let nextImg: any;
+        if (
+          nextFile.extension === 'mp4' ||
+          nextFile.extension === 'webm' ||
+          nextFile.extension === 'ogg'
+        ) {
+          nextImg = document.createElement('video');
+        } else {
+          nextImg = new Image();
+        }
         imageLoader
           .getImageSrc(nextFile)
           .then((src) => isEffectRunning && src && (nextImg.src = encodeFilePath(src)));
       }
       if (!isFirst.get() && fileStore.fileList.length > 0) {
-        const prevImg = new Image();
         const prevFile = fileStore.fileList[uiStore.firstItem - 1];
+        let prevImg: any;
+        if (
+          prevFile.extension === 'mp4' ||
+          prevFile.extension === 'webm' ||
+          prevFile.extension === 'ogg'
+        ) {
+          prevImg = document.createElement('video');
+        } else {
+          prevImg = new Image();
+        }
         imageLoader
           .getImageSrc(prevFile)
           .then((src) => isEffectRunning && src && (prevImg.src = encodeFilePath(src)));
@@ -227,20 +245,34 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({
     thumbnailSrc,
     imgWidth,
     imgHeight,
-    async (source, absolutePath, thumbnailSrc, imgWidth, imgHeight) => {
+    file.extension,
+    async (source, absolutePath, thumbnailSrc, imgWidth, imgHeight, fileExtension) => {
       if (source.tag === 'ready') {
         if ('ok' in source.value) {
           const src = source.value.ok;
           const dimension = await new Promise<{ src: string; dimension: Vec2 }>(
             (resolve, reject) => {
-              const img = new Image();
-              img.onload = function (this: any) {
-                // TODO: would be better to resolve once transition is complete: for large resolution images, the transition freezes for ~.4s bc of a re-paint task when the image changes
-                resolve({
-                  src,
-                  dimension: createDimension(this.naturalWidth, this.naturalHeight),
-                });
-              };
+              let img;
+              if (fileExtension === 'webm' || fileExtension === 'mp4' || fileExtension === 'ogg') {
+                img = document.createElement('video');
+                img.onload = function (this: any) {
+                  // TODO: would be better to resolve once transition is complete: for large resolution images, the transition freezes for ~.4s bc of a re-paint task when the image changes
+                  resolve({
+                    src,
+                    dimension: createDimension(this.videoWidth, this.videoHeight),
+                  });
+                };
+              } else {
+                img = new Image();
+                img.onload = function (this: any) {
+                  // TODO: would be better to resolve once transition is complete: for large resolution images, the transition freezes for ~.4s bc of a re-paint task when the image changes
+                  resolve({
+                    src,
+                    dimension: createDimension(this.naturalWidth, this.naturalHeight),
+                  });
+                };
+              }
+
               img.onerror = reject;
               img.src = encodeFilePath(src);
             },
@@ -259,6 +291,7 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({
   );
 
   if (image.tag === 'ready' && 'err' in image.value) {
+    console.log(image.value.err);
     return <ImageFallback error={image.value.err} absolutePath={absolutePath} />;
   } else {
     const { src, dimension } =
@@ -269,6 +302,38 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({
             dimension: createDimension(imgWidth, imgHeight),
           };
     const minScale = Math.min(0.1, Math.min(width / dimension[0], height / dimension[1]));
+
+    // Alternative case for videos
+    if (file.extension === 'webm' || file.extension === 'mp4' || file.extension === 'ogg') {
+      return (
+        <ZoomPan
+          position="center"
+          initialScale="auto"
+          doubleTapBehavior="zoomOrReset"
+          imageDimension={dimension}
+          containerDimension={createDimension(width, height)}
+          minScale={minScale}
+          maxScale={5}
+          transitionStart={transitionStart}
+          transitionEnd={transitionEnd}
+          onClose={onClose}
+          upscaleMode={upscaleMode}
+        >
+          {(props) => (
+            <video
+              {...props}
+              src={encodeFilePath(src)}
+              width={dimension[0]}
+              height={dimension[1]}
+              controls
+              autoPlay
+              loop
+            />
+          )}
+        </ZoomPan>
+      );
+    }
+
     return (
       <ZoomPan
         position="center"

--- a/src/frontend/containers/Settings/Appearance.tsx
+++ b/src/frontend/containers/Settings/Appearance.tsx
@@ -81,6 +81,21 @@ export const Appearance = observer(() => {
           <Radio value="letterbox">Letterbox</Radio>
         </RadioGroup>
       </div>
+
+      <h3>Gallery Video Playback</h3>
+
+      <div className="vstack">
+        <RadioGroup
+          orientation="horizontal"
+          name="Playback Mode"
+          value={uiStore.galleryVideoPlaybackMode}
+          onChange={uiStore.setGalleryVideoPlaybackMode}
+        >
+          <Radio value="auto">Auto</Radio>
+          <Radio value="hover">Hover</Radio>
+          <Radio value="disabled">Disabled</Radio>
+        </RadioGroup>
+      </div>
     </>
   );
 });

--- a/src/frontend/image/ImageLoader.ts
+++ b/src/frontend/image/ImageLoader.ts
@@ -37,6 +37,9 @@ const FormatHandlers: Record<IMG_EXTENSIONS_TYPE, FormatHandlerType> = {
   // xcf: 'extractEmbeddedThumbnailOnly',
   exr: 'exrLoader',
   // avif: 'sharp',
+  mp4: 'web',
+  webm: 'web',
+  ogg: 'web',
 };
 
 type ObjectURL = string;
@@ -62,7 +65,13 @@ class ImageLoader {
 
   needsThumbnail(file: FileDTO) {
     // Not using thumbnails for gifs, since they're mostly used for animations, which doesn't get preserved in thumbnails
-    if (file.extension === 'gif') {
+    // Not using thumbnails for videos as well
+    if (
+      file.extension === 'gif' ||
+      file.extension === 'webm' ||
+      file.extension === 'mp4' ||
+      file.extension === 'ogg'
+    ) {
       return false;
     }
 

--- a/src/frontend/image/ImageLoader.ts
+++ b/src/frontend/image/ImageLoader.ts
@@ -10,6 +10,7 @@ import StreamZip from 'node-stream-zip';
 import ExrLoader from './ExrLoader';
 import { generateThumbnail, getBlob } from './util';
 import PsdLoader from './PSDLoader';
+import { isFileExtensionVideo } from 'common/fs';
 
 type FormatHandlerType =
   | 'web'
@@ -65,13 +66,8 @@ class ImageLoader {
 
   needsThumbnail(file: FileDTO) {
     // Not using thumbnails for gifs, since they're mostly used for animations, which doesn't get preserved in thumbnails
-    // Not using thumbnails for videos as well
-    if (
-      file.extension === 'gif' ||
-      file.extension === 'webm' ||
-      file.extension === 'mp4' ||
-      file.extension === 'ogg'
-    ) {
+    // Not using thumbnails for videos for now
+    if (file.extension === 'gif' || isFileExtensionVideo(file.extension)) {
       return false;
     }
 

--- a/src/frontend/stores/UiStore.ts
+++ b/src/frontend/stores/UiStore.ts
@@ -21,6 +21,7 @@ export const enum ViewMethod {
 export type ThumbnailSize = 'small' | 'medium' | 'large' | number;
 type ThumbnailShape = 'square' | 'letterbox';
 export type UpscaleMode = 'smooth' | 'pixelated';
+export type GalleryVideoPlaybackMode = 'auto' | 'hover' | 'disabled';
 export const PREFERENCES_STORAGE_KEY = 'preferences';
 
 export interface IHotkeyMap {
@@ -102,6 +103,7 @@ type PersistentPreferenceFields =
   | 'thumbnailSize'
   | 'thumbnailShape'
   | 'upscaleMode'
+  | 'galleryVideoPlaybackMode'
   | 'hotkeyMap'
   | 'isThumbnailTagOverlayEnabled'
   | 'isThumbnailFilenameOverlayEnabled'
@@ -151,6 +153,7 @@ class UiStore {
   @observable thumbnailSize: ThumbnailSize | number = 'medium';
   @observable thumbnailShape: ThumbnailShape = 'square';
   @observable upscaleMode: UpscaleMode = 'smooth';
+  @observable galleryVideoPlaybackMode: GalleryVideoPlaybackMode = 'hover';
 
   @observable isToolbarTagPopoverOpen: boolean = false;
   /** Dialog for removing unlinked files from Allusion's database */
@@ -213,6 +216,22 @@ class UiStore {
 
   @action.bound setUpscaleMode(mode: UpscaleMode) {
     this.upscaleMode = mode;
+  }
+
+  @action.bound setGalleryVideoPlaybackModeAuto() {
+    this.setGalleryVideoPlaybackMode('auto');
+  }
+
+  @action.bound setGalleryVideoPlaybackModeHover() {
+    this.setGalleryVideoPlaybackMode('hover');
+  }
+
+  @action.bound setGalleryVideoPlaybackModeDisabled() {
+    this.setGalleryVideoPlaybackMode('disabled');
+  }
+
+  @action.bound setGalleryVideoPlaybackMode(mode: GalleryVideoPlaybackMode) {
+    this.galleryVideoPlaybackMode = mode;
   }
 
   @action.bound setFirstItem(index: number = 0) {
@@ -814,6 +833,9 @@ class UiStore {
         if (prefs.upscaleMode) {
           this.setUpscaleMode(prefs.upscaleMode);
         }
+        if (prefs.galleryVideoPlaybackMode) {
+          this.setGalleryVideoPlaybackMode(prefs.galleryVideoPlaybackMode);
+        }
         this.isThumbnailTagOverlayEnabled = Boolean(prefs.isThumbnailTagOverlayEnabled ?? true);
         this.isThumbnailFilenameOverlayEnabled = Boolean(prefs.isThumbnailFilenameOverlayEnabled ?? false); // eslint-disable-line prettier/prettier
         this.isThumbnailResolutionOverlayEnabled = Boolean(prefs.isThumbnailResolutionOverlayEnabled ?? false); // eslint-disable-line prettier/prettier
@@ -869,6 +891,7 @@ class UiStore {
       thumbnailSize: this.thumbnailSize,
       thumbnailShape: this.thumbnailShape,
       upscaleMode: this.upscaleMode,
+      galleryVideoPlaybackMode: this.galleryVideoPlaybackMode,
       hotkeyMap: { ...this.hotkeyMap },
       isThumbnailFilenameOverlayEnabled: this.isThumbnailFilenameOverlayEnabled,
       isThumbnailTagOverlayEnabled: this.isThumbnailTagOverlayEnabled,


### PR DESCRIPTION
For #466, adds support for automatic and on hover playback for videos in gallery view. Also allows playback in main view, which has the side effect of allowing sound from non-video .ogg files. Implementation uses web video elements which replace the image elements used normally. I'm unfamiliar with React or Electron so the implementation may not be optimal.

Caveats:
- No thumbnail images
    - As a result video preview will always be on the first frame
- On gallery view, automatic playback of many videos lowers performance by a noticeable amount
