### PR TITLE
fix: Write in place with exiftool

### DIFF
--- a/common/ExifIO.ts
+++ b/common/ExifIO.ts
@@ -57,7 +57,11 @@ console.log('Exif tool path: ', EXIF_TOOL_PATH);
 const ep = new exiftool.ExiftoolProcess(EXIF_TOOL_PATH);
 
 const defaultWriteArgs = [
-  'overwrite_original', // added this because it was leaving behind duplicate files (with _original appended to filename)
+  // overwrite_original to prevent duplicate files appearing.
+  // in_place to prevent changing the file's inode number,
+  // which would desync with the database
+  // and break detection of renamed files
+  'overwrite_original_in_place',
   'codedcharacterset=utf8', // needed for adobe products: https://www.npmjs.com/package/node-exiftool#writing-tags-for-adobe-in-utf8
   'P', // for preserving the modified date of files
 ];


### PR DESCRIPTION
Fixes #623

This fixes issues with the way renamed files are detected from inode numbers, which would become desynced whenever exiftool was used. Any files that had their metadata edited would not be correctly detected as moved, and the web clipper would occasionally overwrite existing database entries, mistaking them for moved files.

Note: using inode numbers for detecting renames is still a potential source of errors because any external tool that overwrites files in this way will also similarly desync the database. This just fixes Allusion desyncing the database with its own operations.